### PR TITLE
[FIX] fiscal position on invoices

### DIFF
--- a/sale_multic_fix/models/sale_order.py
+++ b/sale_multic_fix/models/sale_order.py
@@ -46,9 +46,10 @@ class SaleOrder(models.Model):
             res['fiscal_position_id'])
         if so_fiscal_position.company_id and\
                 so_fiscal_position.company_id.id != company_id:
-            res['fiscal_position_id'] = self.with_context(
-                force_company=company_id).partner_invoice_id\
-                .property_account_position_id.id
+            res['fiscal_position_id'] = \
+                self.env['account.fiscal.position'].with_context(
+                    force_company=company_id).get_fiscal_position(
+                    self.partner_invoice_id.id, self.partner_shipping_id.id)
         return res
 
     # Overwrite this method because odoo filter by company when search the

--- a/sale_multic_fix/models/sale_order_line.py
+++ b/sale_multic_fix/models/sale_order_line.py
@@ -29,9 +29,13 @@ class SaleOrderLine(models.Model):
         # hija
         if self._context.get('force_company') and \
                 company_id != self.company_id.id:
-            fpos = (
-                self.order_id.fiscal_position_id or
-                self.order_id.partner_id.property_account_position_id)
+            # como no tenemos link a la factura tenemos que obtener la fiscal
+            # position que tendria la factura
+            fpos_id = self.env['account.fiscal.position'].with_context(
+                force_company=company_id).get_fiscal_position(
+                self.order_id.partner_id.id,
+                self.order_id.partner_shipping_id.id)
+            fpos = self.env['account.fiscal.position'].browse(fpos_id)
             taxes = self.product_id.taxes_id.filtered(
                 lambda r: company_id == r.company_id.id)
             taxes = fpos.map_tax(taxes) if fpos else taxes


### PR DESCRIPTION
Various fix:
1. change company on an invoice will now refresh taxes if the fp is changed.
2. creation of an invoice from SO of a different company will create taxes on the right company.
3. no more needed to set the fp on the partner when creating an invoices from a SO on a different company (now we get the fp by get_fiscal_position method).