### PR TITLE
[IMP] purchase_multic_fix: fix a bug when validate invoice

### DIFF
--- a/purchase_multic_fix/models/__init__.py
+++ b/purchase_multic_fix/models/__init__.py
@@ -5,3 +5,4 @@
 from . import purchase_order
 from . import purchase_order_line
 from . import account_invoice
+from . import account_invoice_line

--- a/purchase_multic_fix/models/account_invoice.py
+++ b/purchase_multic_fix/models/account_invoice.py
@@ -2,14 +2,24 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models, fields
+# flake8: noqa
+# pylint: disable=pointless-string-statement
+from odoo import api
+from odoo.addons.purchase.models.account_invoice import AccountInvoice
 
 
-class AccountInvoiceLine(models.Model):
-    _inherit = "account.invoice.line"
-
-    # this is tu fix when you are on a child company on an invoice linked to
-    # a PO of the parent company
-    purchase_id = fields.Many2one(
-        related_sudo=True,
-    )
+@api.multi
+def new_write(self, vals):
+    result = True
+    for invoice in self:
+        inv = invoice.sudo()
+        purchase_old = inv.invoice_line_ids.mapped('purchase_line_id.order_id')
+        result = result and super(AccountInvoice, invoice).write(vals)
+        purchase_new = inv.invoice_line_ids.mapped('purchase_line_id.order_id')
+        #To get all po reference when updating invoice line or adding purchase order reference from vendor bill.
+        purchase = (purchase_old | purchase_new) - (purchase_old & purchase_new)
+        if purchase:
+            message = _("This vendor bill has been modified from: %s") % (",".join(["<a href=# data-oe-model=purchase.order data-oe-id="+str(order.id)+">"+order.name+"</a>" for order in purchase]))
+            invoice.message_post(body=message)
+    return result
+AccountInvoice.write = new_write

--- a/purchase_multic_fix/models/account_invoice_line.py
+++ b/purchase_multic_fix/models/account_invoice_line.py
@@ -1,0 +1,15 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models, fields
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = "account.invoice.line"
+
+    # this is tu fix when you are on a child company on an invoice linked to
+    # a PO of the parent company
+    purchase_id = fields.Many2one(
+        related_sudo=True,
+    )


### PR DESCRIPTION
[FIX] move the class "account.invoice.line" to the corresponding file "account_invoice_line.py"
[ADD] use a monkey patch for the write method in invoice to avoid a problem when try to validate an invoice that the origin Purchase order are in a partent company of the invoice company