### PR TITLE
[FIX] purchase_multic_fix: Some wrong behaviour in PO

### DIFF
--- a/purchase_multic_fix/models/purchase_order.py
+++ b/purchase_multic_fix/models/purchase_order.py
@@ -16,3 +16,8 @@ class PurchaseOrder(models.Model):
             raise ValidationError(_(
                 'The picking type company must be the same as the purchase '
                 'order company'))
+
+    @api.onchange('partner_id', 'company_id')
+    def onchange_partner_id(self):
+        return super(PurchaseOrder, self.with_context(
+            force_company=self.company_id.id)).onchange_partner_id()


### PR DESCRIPTION
When you select a partner and the partner has an fiscal position for the company that was you are logging not and you select a different company the fiscal position that the onchange set are from the logging company not for the PO company