### PR TITLE
[FIX] account_multic_fix: In the fp allocation

### DIFF
--- a/account_multic_fix/models/account_invoice.py
+++ b/account_multic_fix/models/account_invoice.py
@@ -92,12 +92,6 @@ class AccountInvoice(models.Model):
         """ This fixes that odoo is not sending the force_company while getting
         the fiscal position (this line: https://bit.ly/2VSbLcA)
         """
-        res = super()._onchange_partner_id()
-        delivery_partner_id = self.get_delivery_partner_id()
-        fiscal_position = self.env[
-            'account.fiscal.position'].with_context(
-                force_company=self.company_id.id).get_fiscal_position(
-                self.partner_id.id, delivery_id=delivery_partner_id)
-        if fiscal_position:
-            self.fiscal_position_id = fiscal_position
+        res = super(AccountInvoice, self.with_context(
+            force_company=self.company_id.id))._onchange_partner_id()
         return res


### PR DESCRIPTION
Use the with_context to force de company of the invoice and send through the call of super in self. This way the second call of method from the method "_finalize_invoices" when the self are not new_id an the constrains are catch in in the moment when change the fp in the method "on_change_partner_id"