### PR TITLE
[12.0] [IMP] account_multicompany_ux: Add companies to user

### DIFF
--- a/account_multicompany_ux/__manifest__.py
+++ b/account_multicompany_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account Multicompany Usability',
-    'version': '12.0.1.0.0',
+    'version': '12.0.1.1.0',
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/account_multicompany_ux/models/__init__.py
+++ b/account_multicompany_ux/models/__init__.py
@@ -18,3 +18,4 @@ from . import res_partner
 from . import product_template
 from . import product_product
 from . import product_category
+from . import res_users

--- a/account_multicompany_ux/models/res_users.py
+++ b/account_multicompany_ux/models/res_users.py
@@ -1,0 +1,23 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import api, models
+
+
+class ResUsers(models.Model):
+
+    _inherit = 'res.users'
+
+    @api.multi
+    def write(self, vals):
+        """ We inherit this to set the company of the partner user to false if the user
+        have more than one companies and the user has multi-company activated"""
+        res = super().write(vals)
+        group_multi_company = self.env.ref('base.group_multi_company', False)
+        if group_multi_company and 'company_ids' in vals:
+            self.filtered(
+                lambda x: x.id in group_multi_company.users.ids
+                and len(x.company_ids) > 1).mapped('partner_id').write(
+                {'company_id': False})
+        return res

--- a/account_multicompany_ux/security/ir.model.access.csv
+++ b/account_multicompany_ux/security/ir.model.access.csv
@@ -1,2 +1,2 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_res_company_property,access_res_company_property,model_res_company_property,,1,1,1,1
+access_res_company_property,access_res_company_property,model_res_company_property,base.group_user,1,1,1,1


### PR DESCRIPTION
In this we clean the company of the partner user, when the user has selected more than one company and have the multi-company group.