### PR TITLE
[11.0] [FIX] account_multic_fix: fix a bug with down payment

### DIFF
--- a/account_multic_fix/models/account_invoice.py
+++ b/account_multic_fix/models/account_invoice.py
@@ -24,7 +24,7 @@ class AccountInvoice(models.Model):
 
         # si viene un default journal y no es de la misma cia que la actual
         # limpiamos el default
-        default_journal_id = self.env.context.get('default_journal_id')
+        default_journal_id = self.env.context.get('default_journal_id') or self.journal_id.id
         if default_journal_id and self.company_id and self.env[
                 'account.journal'].browse(
                     default_journal_id).company_id != self.company_id:


### PR DESCRIPTION
If you do a down payment to a foreign customer, the journal it's change when call the onchange method becase the variable default_journal_id was "None".
To avoid this set if in the context isn't have "default_journal"  use the journal at the invoice in this moment, an then continue with the verification of the journal company.