### PR TITLE
[REM] multic_ux: standard price m2m

### DIFF
--- a/account_multicompany_ux/__manifest__.py
+++ b/account_multicompany_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     'name': 'Account Multicompany Usability',
-    'version': '13.0.1.0.0',
+    'version': '13.0.1.1.0',
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',

--- a/account_multicompany_ux/views/product_product_views.xml
+++ b/account_multicompany_ux/views/product_product_views.xml
@@ -14,9 +14,10 @@
             <field name="property_account_expense_ids" position="attributes">
                 <attribute name="context">{'active_model': 'product.template', 'active_id': product_tmpl_id, 'property_field': 'property_account_expense_id'}</attribute>
             </field>
-            <field name="standard_price_ids" position="attributes">
+            <!-- por ahora desactivamos esta funcionalidad ya que requiere modulo puente con stock_account y price_security para lograr una buena funcionalidad -->
+            <!-- <field name="standard_price_ids" position="attributes">
                 <attribute name="context">{'active_model': 'product.product', 'active_id': id, 'property_field': 'standard_price'}</attribute>
-            </field>
+            </field> -->
         </field>
     </record>
 

--- a/account_multicompany_ux/views/product_template_views.xml
+++ b/account_multicompany_ux/views/product_template_views.xml
@@ -7,18 +7,18 @@
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="groups_id" eval="[(4, ref('base.group_multi_company'))]"/>
         <field name="arch" type="xml">
+            <!-- por ahora desactivamos esta funcionalidad ya que requiere modulo puente con stock_account y price_security para lograr una buena funcionalidad -->
             <!-- standard_price -->
-            <field name="standard_price" position="attributes">
+            <!-- <field name="standard_price" position="attributes">
                 <attribute name="invisible">1</attribute>
-            </field>
+            </field> -->
 
-            <field name="standard_price" position="after">
+            <!-- <field name="standard_price" position="after">
                 <div class="oe_inline">
                     <field name="standard_price_ids" widget="many2many_tags" class="oe_inline" context="{'active_model': 'product.template', 'active_id': id, 'property_field': 'standard_price'}"/>
-                    <!-- pasamos property_domain igual al definido en vista -->
                     <button name="action_company_properties" string="(edit)" class="oe_link" type="object" context="{'property_field': 'standard_price'}"/>
                 </div>
-            </field>
+            </field> -->
 
             <!-- income -->
             <field name="property_account_income_id" position="attributes">


### PR DESCRIPTION
We removed the standard_price m2m functionality because to be implemented coorrectly glue modules with stock_account, price_security and others would be needed. May be we re-introduce this on v15