### PR TITLE
[13.0] [FIX] account_multic_fix: Multi company with currency issues.

### DIFF
--- a/account_multic_fix/models/account_move.py
+++ b/account_multic_fix/models/account_move.py
@@ -44,7 +44,10 @@ class AccountMove(models.Model):
                 line.name = name
                 line.price_unit = price_unit
                 line.product_uom_id = product_uom
-
+            # we need to force change currency
+            if self.currency_id != self.company_id.currency_id:
+                self._onchange_currency()
+                return super()._onchange_journal()
             # si bien onchange partner llama _recompute_dynamic_lines no manda el recompute_all_taxes, este refrezca
             # lineas de impuestos
             self._recompute_dynamic_lines(recompute_all_taxes=True)


### PR DESCRIPTION
When change the journal with a different company and the currency rate is different too. We ensure that values are re-calculated with this new currency rate. Otherwise we got an error when try to save the record, just because the values was keep the old rate.