### PR TITLE
[IMP] multicompany_ux: add suffix on tax and accounts

### DIFF
--- a/account_multicompany_ux/models/__init__.py
+++ b/account_multicompany_ux/models/__init__.py
@@ -11,3 +11,5 @@ from . import product_template
 from . import product_product
 from . import product_category
 from . import res_users
+from . import account_account
+from . import account_tax

--- a/account_multicompany_ux/models/account_account.py
+++ b/account_multicompany_ux/models/account_account.py
@@ -1,0 +1,18 @@
+from odoo import api, models
+
+
+class AccountAccount(models.Model):
+
+    _inherit = 'account.account'
+
+    def name_get(self):
+        """
+        Agregamos sufijo de compañía en reportes financieros si hay más de una compañía seleccionada
+        """
+        res = super().name_get()
+        if self._context.get('model') == 'account.financial.html.report' and len(self._context.get('company_ids')) > 1:
+            new_res = []
+            for record, res in zip(self, res):
+                new_res.append((res[0], '%s%s' % (res[1], record.company_id.get_company_sufix())))
+            return new_res
+        return res

--- a/account_multicompany_ux/models/account_tax.py
+++ b/account_multicompany_ux/models/account_tax.py
@@ -1,0 +1,18 @@
+from odoo import api, models
+
+
+class AccountTax(models.Model):
+    _inherit = 'account.tax'
+
+    def name_get(self):
+        """
+        Agregamos sufijo cuando en el contexto este la key default_type_tax_use, eso quiere decir que es un lugar
+        donde se permiten crear/asociar impuestos, al menos es así en la vista de productos
+        """
+        res = super().name_get()
+        if 'default_type_tax_use' in self._context:
+            new_res = []
+            for record, res in zip(self, res):
+                new_res.append((res[0], '%s%s' % (res[1], record.company_id.get_company_sufix())))
+            return new_res
+        return res

--- a/account_multicompany_ux/models/res_company.py
+++ b/account_multicompany_ux/models/res_company.py
@@ -21,13 +21,14 @@ class ResCompany(models.Model):
 
     # TODO habria que terminar de ver si esta bien este cache o en realidad para
     # ser mas performante no hay que usar nada de self
-    @tools.ormcache_context('self.env.uid', 'self.name', 'self.short_name', keys=('no_company_sufix',))
+    @tools.ormcache_context('self.env.uid', 'self.name', 'self.short_name', keys=('no_company_sufix', 'allowed_company_ids'))
     def get_company_sufix(self):
-        """ Cuando pedimos para unr registro que no tiene cia no queremos que
+        """ Cuando pedimos para un registro que no tiene cia no queremos que
         ensure_one arroje error
         """
         condition =  \
             len(self) != 1 or \
+            len(self._context.get('allowed_company_ids')) <= 1 or \
             self._context.get('no_company_sufix') or \
             not self.env.user.has_group('base.group_multi_company')
 


### PR DESCRIPTION
Lo agregamos para dos casos de usos:
* en productos, que se seleccionan impuestos para más de una compañía
* en informes financieros que se puede visualizar info de más de una cia

Además mejoramos el método que devuelve el suffix para que solo lo haga si hay más de una cia seleccionada