### PR TITLE
account_multicompany_ux: Allow account.move on consolidation company as long as it's a draft

### DIFF
--- a/account_multicompany_ux/models/account_move.py
+++ b/account_multicompany_ux/models/account_move.py
@@ -9,9 +9,9 @@ from odoo.exceptions import ValidationError
 class AccountMove(models.Model):
     _inherit = 'account.move'
 
-    @api.constrains('company_id')
+    @api.constrains('company_id', 'state')
     def check_company(self):
         for move in self:
-            if move.company_id.consolidation_company:
+            if move.company_id.consolidation_company and move.state != 'draft':
                 raise ValidationError(_(
                     'You can not create entries on a consolidation company'))


### PR DESCRIPTION
After the merging of `account.invoice` and `account.move`, this change is necessary to support creating a sale order in the consolidation company, creating a draft invoice from the SO, moving the invoice to another company (using `account_multic_fix`) and finally posting the invoice.