### PR TITLE
[FIX] account_multic_fix: modules update

### DIFF
--- a/account_multic_fix/__manifest__.py
+++ b/account_multic_fix/__manifest__.py
@@ -19,13 +19,14 @@
 ##############################################################################
 {
     'name': 'Account Multi Company Fixes',
-    'version': '13.0.1.0.0',
+    'version': '13.0.1.1.0',
     'author': 'ADHOC SA',
     'website': 'www.adhoc.com.ar',
     'license': 'AGPL-3',
     'category': 'Accounting & Finance',
     'depends': ['account'],
     'data': [
+        'views/account_bank_statement_line_views.xml',
     ],
     'demo': [],
     'installable': True,

--- a/account_multic_fix/views/account_bank_statement_line_views.xml
+++ b/account_multic_fix/views/account_bank_statement_line_views.xml
@@ -1,0 +1,14 @@
+<odoo>
+
+    <record id="view_bank_statement_line_form" model="ir.ui.view">
+        <field name="name">bank.statement.line.form</field>
+        <field name="model">account.bank.statement.line</field>
+        <field name="inherit_id" ref="account.view_bank_statement_line_form"/>
+        <field name="arch" type="xml">
+            <form>
+                <field name="company_id"/>
+            </form>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Este modulo está agreando check_company en campos de account bank statement line, eso hace que odoo agregue automáticamente un dominio relativo a las compañías, pero si en la vista no está el campo company_id esto da error.

Este problema no saltaba en este modulo porque este modulo en si no toca la vista, el problema surgió cuando otro módulo quiso heredar esta vista form de los statement lines