### PR TITLE
[FIX] account_multicompany_ux: Correct behavior of name_search with a single company when having this module installed

### DIFF
--- a/account_multicompany_ux/models/account_journal.py
+++ b/account_multicompany_ux/models/account_journal.py
@@ -12,10 +12,15 @@ class AccountJournal(models.Model):
     @api.depends('name', 'currency_id', 'company_id', 'company_id.currency_id')
     def _compute_display_name(self):
         """
-        No llamamos a super porque tendriamos que igualmente hacer un read
-        para obtener la compania y no queremos disminuir la performance. Este método lo que haría es agregar el nombre de la compañía entre paréntesis al final del nombre del diario cuando uno ingresa a la vista form esto lo hace en el nombre que está en el menú hamburguesa.
+        Este método lo que haría es agregar el nombre de la compañía entre paréntesis al final del nombre del diario 
+        cuando uno ingresa a la vista form esto lo hace en el nombre que está en el menú hamburguesa.
+        en caso de que {journal.company_id.get_company_sufix()} sea False llamamos a super para mantener el comportamiento
+        nativo de odoo
         """
         for journal in self:
             currency = journal.currency_id or journal.company_id.currency_id
-            name = f"{journal.name} ({currency.name}) {journal.company_id.get_company_sufix()}"
-            journal.display_name = name
+            if journal.company_id.get_company_sufix():
+                name = f"{journal.name} ({currency.name}) {journal.company_id.get_company_sufix()}"
+                journal.display_name = name
+            else:
+                super()._compute_display_name()


### PR DESCRIPTION
When the account_multicompany_ux module is installed and only one company is set up, the name_search function does not return all available journals when creating a new payment or invoice. 
Instead, it incorrectly prompts the user to create a new journal using the name of the default journal, even though existing journals that could be selectable.

Steps to reproduce:

1- Install the account_multicompany_ux module.
2- Ensure that you have only one company seting up.
3- Attempt to create a new payment or invoice.
4- In the journal selection field, observe that not all eligible journals are listed. Instead, there is an option to create a new journal, which should not be necessary.

This commit corrects the name_search behavior, ensuring that all eligible journals are displayed following the native behavior of odoo, providing a complete and accurate list for selection during payment or invoice creation.

Video with the issue --> https://drive.google.com/file/d/1xlceuKla-nVSmRB3aBtE1okSKGxaw4MZ/view