### PR TITLE
[ADD] _multicompany_ux: re-add standard price m2m on views

### DIFF
--- a/account_multicompany_ux/__manifest__.py
+++ b/account_multicompany_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account Multicompany Usability",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/account_multicompany_ux/models/product_product.py
+++ b/account_multicompany_ux/models/product_product.py
@@ -24,7 +24,7 @@ class ProductProduct(models.Model):
     )
     standard_price_ids = fields.Many2many(
         "res.company.property",
-        string="Accounting Costs",
+        string="Costs",
         compute="_compute_properties",
     )
 

--- a/account_multicompany_ux/models/product_template.py
+++ b/account_multicompany_ux/models/product_template.py
@@ -22,7 +22,7 @@ class ProductTemplate(models.Model):
     )
     standard_price_ids = fields.Many2many(
         "res.company.property",
-        string="Accounting Costs",
+        string="Costs",
         compute="_compute_properties",
     )
 

--- a/account_multicompany_ux/views/product_product_views.xml
+++ b/account_multicompany_ux/views/product_product_views.xml
@@ -13,10 +13,9 @@
             <field name="property_account_expense_ids" position="attributes">
                 <attribute name="context">{'active_model': 'product.template', 'active_id': product_tmpl_id, 'property_field': 'property_account_expense_id'}</attribute>
             </field>
-            <!-- por ahora desactivamos esta funcionalidad ya que requiere modulo puente con stock_account y price_security para lograr una buena funcionalidad -->
-            <!-- <field name="standard_price_ids" position="attributes">
+            <field name="standard_price_ids" position="attributes">
                 <attribute name="context">{'active_model': 'product.product', 'active_id': id, 'property_field': 'standard_price'}</attribute>
-            </field> -->
+            </field>
         </field>
     </record>
 

--- a/account_multicompany_ux/views/product_template_views.xml
+++ b/account_multicompany_ux/views/product_template_views.xml
@@ -6,18 +6,20 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
-            <!-- por ahora desactivamos esta funcionalidad ya que requiere modulo puente con stock_account y price_security para lograr una buena funcionalidad -->
             <!-- standard_price -->
-            <!-- <field name="standard_price" position="attributes">
-                <attribute name="invisible">1</attribute>
-            </field> -->
-
-            <!-- <field name="standard_price" position="after">
-                <div class="oe_inline">
+            <label for="standard_price" position="attributes">
+                <attribute name="string">Costs</attribute>
+                <attribute name="for">name</attribute>
+            </label>
+            <field name="standard_price" position="attributes">
+                <attribute name="groups">!base.group_multi_company</attribute>
+            </field>
+            <field name="standard_price" position="after">
+                <div class="oe_inline" groups="base.group_multi_company">
                     <field name="standard_price_ids" widget="many2many_tags" class="oe_inline" context="{'active_model': 'product.template', 'active_id': id, 'property_field': 'standard_price'}"/>
                     <button name="action_company_properties" string="(edit)" class="oe_link" type="object" context="{'property_field': 'standard_price'}"/>
                 </div>
-            </field> -->
+            </field>
 
             <!-- income -->
             <field name="property_account_income_id" position="attributes">


### PR DESCRIPTION
No encontramos porque seria un problema de compatibilidad con stock_account, tal vez algo cambio en las ultimas versiones. Por lo que vimos tampoco habria problema de compatibilidad con price_security porque ahora el standar_price original esta en un div que es el que oculta price_security y por ende tmb queda oculto standar_price_ids Lo unico que hicimos fue en price_security agregar cierta compatibilidad para ocultar boton editar cuando corresponda