### PR TITLE
[IMP] account_multicompany_ux: Make credit field a property company field

### DIFF
--- a/account_multicompany_ux/__manifest__.py
+++ b/account_multicompany_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Account Multicompany Usability",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/account_multicompany_ux/models/res_company_property.py
+++ b/account_multicompany_ux/models/res_company_property.py
@@ -76,6 +76,17 @@ class ResCompanyProperty(models.Model):
         compute="_compute_property_pricelist",
         inverse="_inverse_property_pricelist",
     )
+    property_credit_id = fields.Float(
+        string="Credit",
+        compute="_compute_property_credit",
+        inverse="_inverse_property_credit",
+    )
+    # Nuevo campo para credit con moneda
+    property_credit_currency_id = fields.Many2one(
+        "res.currency",
+        string="Credit Currency",
+        compute="_compute_property_credit_currency",
+    )
     standard_price = fields.Float(
         string="standard_price",
         compute="_compute_property_standard_price",
@@ -149,6 +160,8 @@ class ResCompanyProperty(models.Model):
             property_field = self._context.get("property_field")
             if property_field == "standard_price":
                 company_property_field = "standard_price"
+            elif property_field == "credit":
+                company_property_field = "property_credit_id"
             else:
                 raise UserError(_("Property for model %s not implemented yet", comodel))
         return company_property_field
@@ -177,7 +190,16 @@ class ResCompanyProperty(models.Model):
                 company_field = company_field and round(company_field, precision_digits)
                 # company_field = company_field and float_round(
                 #     company_field, precision_digits=precision_digits)
-                display_name = "%s%s" % (company_field or _("None"), rec.company_id.get_company_sufix())
+
+                # Si es el campo credit, incluir la moneda
+                if rec.property_field == "credit" and rec.property_credit_currency_id:
+                    display_name = "%s %s%s" % (
+                        rec.property_credit_currency_id.symbol or rec.property_credit_currency_id.name,
+                        company_field or 0,
+                        rec.company_id.get_company_sufix(),
+                    )
+                else:
+                    display_name = "%s%s" % (company_field or _("None"), rec.company_id.get_company_sufix())
             else:
                 display_name = "%s%s" % (company_field.display_name or _("None"), rec.company_id.get_company_sufix())
             rec.display_name = display_name
@@ -254,6 +276,23 @@ class ResCompanyProperty(models.Model):
             else:
                 record.property_pricelist_id = False
 
+    @api.depends("property_field")
+    def _compute_property_credit(self):
+        for record in self:
+            if record.property_field == "credit":
+                record.property_credit_id = record._get_property_value()
+            else:
+                record.property_credit_id = 0
+
+    @api.depends("property_field")
+    def _compute_property_credit_currency(self):
+        for record in self:
+            if record.property_field == "credit":
+                # Obtener la moneda de la compañía
+                record.property_credit_currency_id = record.company_id.currency_id
+            else:
+                record.property_credit_currency_id = False
+
     def _set_property_value(self, value):
         self.ensure_one()
         record = self._get_record()
@@ -277,6 +316,10 @@ class ResCompanyProperty(models.Model):
     def _inverse_property_pricelist(self):
         for rec in self:
             rec._set_property_value(rec.property_pricelist_id.id)
+
+    def _inverse_property_credit(self):
+        for rec in self:
+            rec._set_property_value(rec.property_credit_id)
 
     def _inverse_property_standard_price(self):
         for rec in self:

--- a/account_multicompany_ux/models/res_company_property_mixin.py
+++ b/account_multicompany_ux/models/res_company_property_mixin.py
@@ -28,6 +28,8 @@ class ResCompanyPropertyMixin(models.AbstractModel):
             view_id = self.env.ref("account_multicompany_ux.view_property_term_id_form").id
         elif self._context.get("property_field") == "property_product_pricelist":
             view_id = self.env.ref("account_multicompany_ux.view_property_pricelist_id_form").id
+        elif self._context.get("property_field") == "credit":
+            view_id = self.env.ref("account_multicompany_ux.view_property_credit_form").id
         elif self._context.get("property_field") == "property_supplier_payment_term_id":
             view_id = self.env.ref("account_multicompany_ux.view_property_term_id_form").id
         elif self._context.get("property_field").startswith("property_account"):

--- a/account_multicompany_ux/models/res_partner.py
+++ b/account_multicompany_ux/models/res_partner.py
@@ -19,6 +19,7 @@ class ResPartner(models.Model):
         "property_payment_term_ids",
         "property_supplier_payment_term_ids",
         "property_product_pricelist_ids",
+        "property_credit_ids",
     }
 
     property_account_receivable_ids = fields.Many2many(
@@ -52,6 +53,12 @@ class ResPartner(models.Model):
         compute="_compute_properties",
     )
 
+    property_credit_ids = fields.Many2many(
+        "res.company.property",
+        string="Credit",
+        compute="_compute_properties",
+    )
+
     def _compute_properties(self):
         property_fields = dict(
             property_account_receivable_ids="property_account_receivable_id",
@@ -60,6 +67,7 @@ class ResPartner(models.Model):
             property_payment_term_ids="property_payment_term_id",
             property_supplier_payment_term_ids=("property_supplier_payment_term_id"),
             property_product_pricelist_ids="property_product_pricelist",
+            property_credit_ids="credit",
         )
         for rec in self:
             company_properties = self.env["res.company.property"].with_context(

--- a/account_multicompany_ux/views/res_company_property_views.xml
+++ b/account_multicompany_ux/views/res_company_property_views.xml
@@ -56,6 +56,18 @@
             </list>
         </field>
     </record>
+    <record id="view_property_credit_form" model="ir.ui.view">
+        <field name="name">res.company.property.form</field>
+        <field name="model">res.company.property</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="account_multicompany_ux.view_res_company_account_property_form"></field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="property_credit_currency_id" />
+                <field name="property_credit_id" />
+            </list>
+        </field>
+    </record>
     <record id="view_standard_price_form" model="ir.ui.view">
         <field name="name">res.company.property.form</field>
         <field name="model">res.company.property</field>

--- a/account_multicompany_ux/views/res_partner_views.xml
+++ b/account_multicompany_ux/views/res_partner_views.xml
@@ -92,6 +92,14 @@
                     <button name="action_company_properties" string="(edit)" class="oe_link" type="object" context="{'property_field': 'property_product_pricelist'}" invisible="not is_company and parent_id"/>
                 </div>
             </field>
+
+            <!-- credit -->
+            <field name="credit" position="after">
+                <label for="property_credit_ids"/>
+                <div class="oe_inline">
+                    <field name="property_credit_ids" widget="many2many_tags" context="{'active_model': 'res.partner', 'active_id': id, 'property_field': 'credit'}"/>
+                </div>
+            </field>
         </field>
     </record>
 


### PR DESCRIPTION

The `credit` field in partners is now a company-dependent property field. This change allows to properly track outstanding credit per company, instead of sharing a single value across all companies.

As a result, when a partner is selected in a multi-company environment, the displayed credit reflects the correct balance for the active company. This improves usability and avoids inconsistencies in multi-company setups.