### PR TITLE
[FIX] account_multicompany_ux:  Exclude non-relevant line types from downpayment lines filter

### DIFF
--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -133,7 +133,9 @@ class AccountChangeCurrency(models.TransientModel):
         )
         downpayment_lines = self.env["account.move.line"]
         if self.move_id.invoice_line_ids._fields.get("is_downpayment"):
-            downpayment_lines = self.move_id.invoice_line_ids.filtered("is_downpayment")
+            downpayment_lines = self.move_id.invoice_line_ids.filtered(
+                lambda x: x.is_downpayment and x.display_type not in ("line_section", "line_note")
+            )
         (self.move_id.line_ids - without_product - downpayment_lines).with_company(
             self.company_id.id
         )._compute_account_id()


### PR DESCRIPTION

In order to not compute account in line that doesn`t apply