### PR TITLE
[FIX] account_multicompany_ux: Fix partner creation error when property_field is missing

### DIFF
--- a/account_multicompany_ux/models/res_company_property.py
+++ b/account_multicompany_ux/models/res_company_property.py
@@ -151,7 +151,7 @@ class ResCompanyProperty(models.Model):
         property_field = self.env.context.get("property_field")
 
         # Si no hay comodel o property_field, retornar None para evitar el error
-        if not comodel and not property_field:
+        if not comodel or not property_field:
             return None
 
         if comodel == "account.account":


### PR DESCRIPTION

The _get_company_property_field() method was raising a UserError "Property for model None not implemented yet" when creating partners without property_field context.

The validation condition used 'and' instead of 'or', which only returned None when both comodel and property_field were falsy. When only comodel was None, the code continued to the else clause that raised the error.

Changed to 'or' so None is returned when either value is missing, preventing the error. The _compute_display_name() method already handles None values correctly.