### PR TITLE
[FIX] account_multicompany_ux: recómputo de impuestos al cambiar la compañía (también cambia la posición fiscal)

### DIFF
--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -169,6 +169,9 @@ class AccountChangeCurrency(models.TransientModel):
         # para percepciones argentinas re-computamos con su propio método
         if self.move_id.fiscal_position_id._fields.get("l10n_ar_tax_ids"):
             self.move_id._l10n_ar_recompute_fiscal_position_taxes()
+            # necesitamos que recompute los impuestos al cambiar la posición fiscal
+            # cuando hay cambio de compañía
+            self.move_id._onchange_fiscal_position_id()
 
         # PARTNER BANK
         if original_partner_bank_id and original_partner_bank_id.company_id.id in [False, self.company_id.id]:


### PR DESCRIPTION
Ticket: 110931
Necesitamos que se recompute los impuestos al cambiar la posición fiscal en una factura cuando hay cambio de compañía.