### PR TITLE
Revert "[FIX] account_multicompany_ux: recómputo de impuestos al camb…

### DIFF
--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -169,9 +169,6 @@ class AccountChangeCurrency(models.TransientModel):
         # para percepciones argentinas re-computamos con su propio método
         if self.move_id.fiscal_position_id._fields.get("l10n_ar_tax_ids"):
             self.move_id._l10n_ar_recompute_fiscal_position_taxes()
-            # necesitamos que recompute los impuestos al cambiar la posición fiscal
-            # cuando hay cambio de compañía
-            self.move_id._onchange_fiscal_position_id()
 
         # PARTNER BANK
         if original_partner_bank_id and original_partner_bank_id.company_id.id in [False, self.company_id.id]:


### PR DESCRIPTION
…iar la compañía (también cambia la posición fiscal)"

This reverts commit 832699f4e52ad814da752079041ede71f4a98ff4.

Revertiimos porque este caso de uso:
a) puede romper flujos actuales (de downpayments y otros)

b) ya estamos cambiando las perecepciones (pero no otros taxes) c) en 19 cambio de company (branch) NO va a recomputar fiscal position, el usuario va a tener que re-computarla

en 18 es medio "feo" que si tenés distintas FPs (o distinta lógica de auto detección), cambiar de cia te cambia la FP pero NO re computa tax (que no sean percepeciones). Esto no estuvo pensado así, la idea era que cambiar de cia tenga mismo mapeo de FP y retome fp análoga en la otra cia (en 19 directamente NO va a haber cambio de FP)

eventualmente podríamos agregar en wizard de cambio de compañía / branch puedas elegir otra FP y que esa FP actualice todos los taxes