### PR TITLE
[ADD] stock_account_multicompany_ux: Add new module

### DIFF
--- a/account_multicompany_ux/models/res_company.py
+++ b/account_multicompany_ux/models/res_company.py
@@ -2,6 +2,7 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
+
 from odoo import fields, models, tools
 
 
@@ -13,7 +14,7 @@ class ResCompany(models.Model):
     )
 
     consolidation_company = fields.Boolean(
-        help="Journal entries are not allowed on consolidation companies. (so" " invoices, payments, etc neither)"
+        help="Journal entries are not allowed on consolidation companies. (so invoices, payments, etc neither)"
     )
 
     # TODO habria que terminar de ver si esta bien este cache o en realidad para

--- a/stock_account_multicompany_ux/README.rst
+++ b/stock_account_multicompany_ux/README.rst
@@ -1,0 +1,84 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+====================================
+Stock Account Multicompany Usability
+====================================
+
+Extends the stock-accounting integration for multi-company setups where a parent
+company has one or more branch companies. The key feature is **Shared Stock
+Valuation to Branches**: branches calculate COGS using the parent company's
+inventory cost instead of their own, ensuring a single unified cost across
+the entire group.
+
+Features
+--------
+
+- **Shared Stock Valuation to Branches** (``product.category``): new boolean
+  field on product categories. When enabled on the parent company, the parent's
+  costing method and standard price are automatically propagated to all
+  accessible branches. The field is hidden for branch users.
+
+- **Branch-aware COGS price** (``stock.move``): overrides
+  ``_get_cogs_price_unit()`` so that when a branch generates COGS entries for
+  a category with shared valuation, the cost is taken from the parent company.
+  Supports standard, average, and FIFO cost methods. For FIFO it looks up
+  equivalent parent-company stock moves; when none exist it falls back to the
+  parent's last stock valuation layer or standard price.
+
+- **Branch-aware COGS value** (``account.move.line``): overrides
+  ``_get_cogs_value()`` to apply the same parent-cost logic even when there are
+  no associated stock moves (e.g. service products billed from a branch, or
+  credit notes). Also respects reversed-entry lines to avoid re-computing
+  already-posted COGS.
+
+- **Inventory difference lines** (``account.move``): overrides
+  ``_stock_account_prepare_realtime_out_lines_vals()`` to post the price
+  difference between the branch cost and the parent cost to the appropriate
+  inventory difference account when real-time valuation is active.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Install ``account_multicompany_ux`` and ``stock_account`` (declared as
+   dependencies; they are installed automatically).
+#. Install this module.
+
+Configuration
+=============
+
+#. On the **parent** company, open **Inventory → Configuration → Product
+   Categories** and edit the category you want to share.
+#. In the *Account Properties* tab, enable **Shared Stock Valuation to
+   Branches**.
+#. Save. The module will immediately propagate the costing method and valuation
+   type to all branches that the current user can access.
+
+.. note::
+   The **Shared Stock Valuation to Branches** field is only visible when
+   multi-company mode is active and the current company is *not* a branch
+   (i.e. it has no parent company).
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/ingadhoc/multi-company/issues>`_.
+
+Credits
+=======
+
+Authors
+~~~~~~~
+
+* |company|

--- a/stock_account_multicompany_ux/__init__.py
+++ b/stock_account_multicompany_ux/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_account_multicompany_ux/__manifest__.py
+++ b/stock_account_multicompany_ux/__manifest__.py
@@ -1,0 +1,36 @@
+##############################################################################
+#
+#    Copyright (C) 2015  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Stock Account Multicompany Usability",
+    "version": "19.0.1.0.0",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "depends": [
+        "stock_account",
+        "account_multicompany_ux",
+    ],
+    "data": [
+        "views/product_category_views.xml",
+    ],
+    "demo": [],
+    "installable": True,
+    "auto_install": True,
+}

--- a/stock_account_multicompany_ux/models/__init__.py
+++ b/stock_account_multicompany_ux/models/__init__.py
@@ -1,0 +1,5 @@
+from . import account_move_line
+from . import stock_move
+from . import product_category
+from . import account_move
+from . import res_company

--- a/stock_account_multicompany_ux/models/account_move.py
+++ b/stock_account_multicompany_ux/models/account_move.py
@@ -1,0 +1,59 @@
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _stock_account_prepare_realtime_out_lines_vals(self):
+        """
+        Override para agregar líneas de diferencia de inventario en facturas
+        emitidas por compañías branch cuya categoría de producto tiene
+        'shared_to_branches' habilitado.
+
+        Cuando una branch usa el costo de la compañía padre, puede existir una
+        diferencia entre el precio registrado en la branch y el costo real del
+        padre. Este override genera asientos adicionales (líneas de tipo COGS)
+        para registrar esa diferencia en la factura.
+
+        Flujo:
+        1. Llama al super() para obtener las líneas COGS base.
+        2. Solo continúa si la compañía del asiento es una branch (tiene parent_id).
+        3. Para cada línea de factura que cumple las condiciones (categoría compartida,
+           valoración en tiempo real), busca movimientos de stock 'done' y verifica
+           si hubo diferencia de precio registrada en el contexto del move.
+        4. Si hay diferencia, construye las líneas adicionales y las agrega a la lista.
+        """
+        lines_vals_list = super()._stock_account_prepare_realtime_out_lines_vals()
+
+        # Solo proceder si la compañía es una branch (tiene compañía padre).
+        # Las compañías padre calculan su propio COGS sin este override.
+        if not self.company_id.parent_id:
+            return lines_vals_list
+
+        # Iterar únicamente líneas de factura cuyo producto pertenece a una
+        # categoría con 'shared_to_branches' activo. El resto usa el flujo
+        # estándar de Odoo sin modificaciones.
+        for line in self.invoice_line_ids.filtered(lambda x: x.product_id.categ_id.shared_to_branches):
+            # Saltar líneas que no generan COGS o productos sin valoración en tiempo real
+            if not line._eligible_for_stock_account() or line.product_id.valuation != "real_time":
+                continue
+
+            # Obtener los movimientos de stock completados asociados a esta línea de factura
+            stock_moves = line._get_stock_moves().filtered(lambda m: m.state == "done")
+
+            for move in stock_moves:
+                # La diferencia de inventario se registra en el contexto del move
+                # durante el proceso de valoración (ver stock_move._get_cogs_price_unit).
+                # Si no hay diferencia registrada, no hay nada que asentar.
+                if move._context.get("inventory_price_difference"):
+                    price_difference = move._context["inventory_price_difference"]
+                    price_diff_account_id = move._context.get("inventory_diff_account")
+
+                    if price_diff_account_id:
+                        # Delegar la construcción de los vals al método dedicado en stock.move
+                        diff_lines = self.env["stock.move"]._prepare_inventory_difference_lines(
+                            self, line, price_difference, self.env["account.account"].browse(price_diff_account_id)
+                        )
+                        lines_vals_list.extend(diff_lines)
+
+        return lines_vals_list

--- a/stock_account_multicompany_ux/models/account_move_line.py
+++ b/stock_account_multicompany_ux/models/account_move_line.py
@@ -1,0 +1,99 @@
+from odoo import models
+
+
+class AccountMoveLine(models.Model):
+    _inherit = "account.move.line"
+
+    def _get_cogs_value(self):
+        """
+        Override para calcular el COGS (costo de mercadería vendida) usando el
+        costo de la compañía PADRE cuando la línea pertenece a una factura
+        emitida por una branch con categoría de producto compartida.
+
+        Contexto:
+        - En un esquema multi-compañía con branches, el inventario físico y su
+          valoración pueden vivir en la compañía padre.
+        - Cuando la branch emite una factura, el costo del producto debe tomarse
+          del padre para reflejar fielmente el costo real del inventario vendido.
+        - Solo aplica si la categoría del producto tiene 'shared_to_branches' activo.
+
+        Orden de prioridad para determinar el precio unitario:
+        1. Precio del asiento original revertido (facturas de rectificación/NC).
+        2. stock.move._get_cogs_price_unit() si hay stock moves completados
+           (ese método ya tiene su propio override para usar el costo del padre).
+        3. Precio estándar del padre (si no hay stock moves, método standard/average).
+        4. Última capa SVL del padre como aproximación FIFO.
+        5. Precio estándar del padre como fallback final.
+        """
+        self.ensure_one()
+
+        # Identificar la compañía de la factura y su eventual compañía padre
+        branch_company = self.move_id.company_id
+        parent_company = branch_company.parent_id
+
+        # Si no hay compañía padre, esta no es una branch → flujo estándar de Odoo
+        if not parent_company:
+            return super()._get_cogs_value()
+
+        # Solo interceptar si la categoría del producto está marcada como compartida.
+        # Para el resto de categorías, la branch tiene su propio inventario y costo.
+        if not self.product_id.categ_id.shared_to_branches:
+            return super()._get_cogs_value()
+
+        # --- Caso 1: Línea de nota de crédito (rectificación) ---
+        # Si la factura original ya tiene COGS contabilizado, reutilizar ese precio
+        # para garantizar simetría contable y evitar recalcular.
+        original_line = self.move_id.reversed_entry_id.line_ids.filtered(
+            lambda l: (
+                l.display_type == "cogs"
+                and l.product_id == self.product_id
+                and l.product_uom_id == self.product_uom_id
+                and l.price_unit >= 0
+            )
+        )
+        original_line = original_line and original_line[0]
+        if original_line:
+            return original_line.price_unit
+
+        # Validaciones básicas: sin producto o cantidad cero no hay COGS que calcular
+        if not self.product_id or self.product_uom_id.is_zero(self.quantity):
+            return self.price_unit
+
+        cogs_qty = self._get_cogs_qty()
+
+        if moves := self._get_stock_moves().filtered(lambda m: m.state == "done"):
+            # --- Caso 2: Hay movimientos de stock completados ---
+            # Delegar a stock.move._get_cogs_price_unit(), que está override-ado
+            # para retornar el costo de la compañía padre en lugar del de la branch.
+            price_unit = moves._get_cogs_price_unit(cogs_qty)
+        else:
+            # --- Caso 3: Sin movimientos de stock ---
+            # (ej. servicio con valoración, venta sin picking, ajuste manual)
+            # Obtener el costo directamente desde la compañía padre.
+            product_parent = self.product_id.with_company(parent_company)
+
+            if product_parent.cost_method in ["standard", "average"]:
+                # Standard/Average: usar el precio estándar vigente en el padre
+                price_unit = product_parent.standard_price
+            else:
+                # FIFO: leer la última capa de valoración (SVL) del padre.
+                # No se consume ni ajusta ninguna capa; es solo una lectura del costo.
+                StockValuationLayer = self.env["stock.valuation.layer"]
+                svl = StockValuationLayer.search(
+                    [
+                        ("product_id", "=", product_parent.id),
+                        ("company_id", "=", parent_company.id),
+                    ],
+                    order="id desc",
+                    limit=1,
+                )
+                if svl:
+                    # Usar el costo unitario de la última capa como aproximación FIFO
+                    price_unit = svl.unit_cost
+                else:
+                    # Sin capas previas disponibles: caer al precio estándar del padre
+                    price_unit = product_parent.standard_price
+
+        # Descontar el valor de COGS ya contabilizado en asientos anteriores
+        # (ej. entregas parciales previamente facturadas) para evitar doble registro.
+        return (price_unit * cogs_qty - self._get_posted_cogs_value()) / self.quantity

--- a/stock_account_multicompany_ux/models/product_category.py
+++ b/stock_account_multicompany_ux/models/product_category.py
@@ -1,0 +1,95 @@
+from odoo import api, fields, models
+
+
+class ProductCategory(models.Model):
+    """
+    Extiende product.category para soportar la propagación de configuración
+    de valoración de inventario desde una compañía padre hacia sus branches.
+
+    El campo clave es 'shared_to_branches': cuando está activo en una categoría,
+    todas las branches heredan el método de costeo y el precio estándar definidos
+    en la compañía padre, garantizando un costo único para todo el grupo.
+    """
+
+    _inherit = "product.category"
+
+    is_branch_company = fields.Boolean(
+        compute="_compute_is_branch_company",
+        help="True when the active company is a branch (has a parent company).",
+    )
+
+    shared_to_branches = fields.Boolean(
+        string="Shared Stock Valuation to Branches",
+        help=(
+            "When enabled, all branches of the parent company will use the same "
+            "costing method and standard price defined in the parent company for "
+            "products in this category. This ensures a single unified cost across "
+            "the parent and all its branches."
+        ),
+    )
+
+    def write(self, vals):
+        res = super().write(vals)
+        # Si se modificaron campos de valoración o el flag 'shared_to_branches',
+        # propagar la configuración a las branches para mantener coherencia.
+        propagate_fields = {"shared_to_branches", "property_cost_method", "property_valuation"}
+        if propagate_fields & vals.keys():
+            self._propagate_valuation_to_branches()
+        return res
+
+    def create(self, vals_list):
+        if isinstance(vals_list, dict):
+            vals_list = [vals_list]
+        categs = super().create(vals_list)
+        # Si la categoría se crea con shared_to_branches desde el inicio,
+        # propagar la configuración de valoración a las branches inmediatamente.
+        for categ, vals in zip(categs, vals_list):
+            if vals.get("shared_to_branches"):
+                categ._propagate_valuation_to_branches()
+        return categs
+
+    def _propagate_valuation_to_branches(self):
+        """
+        Copia property_cost_method y property_valuation desde la compañía activa
+        (padre) hacia todas las branches accesibles, para cada categoría que tenga
+        'shared_to_branches' habilitado.
+
+        Solo propaga si el método es llamado en contexto de la compañía PADRE.
+        Si se llama desde una branch (parent_id existe), se ignora para evitar
+        propagaciones inversas o circulares.
+        """
+        for categ in self.filtered("shared_to_branches"):
+            parent_company = self.env.company
+
+            # Guardia: solo propagar desde la compañía padre, nunca desde una branch.
+            if parent_company.parent_id:
+                continue
+
+            # Obtener las branches accesibles (excluye a la propia compañía padre)
+            branches = parent_company._accessible_branches() - parent_company
+            if not branches:
+                continue
+
+            # Leer la configuración de valoración definida en el padre
+            parent_cost_method = categ.with_company(parent_company).property_cost_method
+            parent_valuation = categ.with_company(parent_company).property_valuation
+
+            # Escribir la misma configuración en el contexto de cada branch
+            for branch in branches:
+                categ.with_company(branch).write(
+                    {
+                        "property_cost_method": parent_cost_method,
+                        "property_valuation": parent_valuation,
+                    }
+                )
+
+    @api.depends_context("company")
+    def _compute_is_branch_company(self):
+        """
+        Indica si la compañía activa es una branch (tiene parent_id).
+        Depende del contexto de compañía para recalcularse al cambiar de empresa.
+        Se usa en la vista para mostrar/ocultar campos relevantes solo para branches.
+        """
+        is_branch = bool(self.env.company.parent_id)
+        for categ in self:
+            categ.is_branch_company = is_branch

--- a/stock_account_multicompany_ux/models/res_company.py
+++ b/stock_account_multicompany_ux/models/res_company.py
@@ -1,0 +1,111 @@
+from collections import defaultdict
+
+from odoo import models
+from odoo.fields import Domain
+
+
+class ResCompany(models.Model):
+    """
+    Override de res.company para adaptar el cálculo del valor contable de
+    inventario (stock_accounting_value) al modelo de branches con valoración
+    compartida.
+
+    Problema que resuelve:
+    - En un grupo con padre + branches, los productos con 'shared_to_branches'
+      registran sus recepciones/compras en el padre, pero las ventas (COGS)
+      en las branches.
+    - Sin este override, el padre duplicaría el stock (contaría el suyo +
+      el de las branches) o las branches lo contarían sin haberlo recibido
+      físicamente, inflando los reportes de valoración de inventario.
+
+    Solución:
+    - Compañía PADRE: suma sus propios AMLs de productos NO compartidos, más
+      todos los AMLs del grupo (padre + branches) de productos compartidos.
+      Así consolida el inventario real del grupo en una sola cifra.
+    - Compañía BRANCH: suma solo sus propios AMLs de productos NO compartidos.
+      Los productos compartidos quedan excluidos para evitar doble conteo con
+      el padre.
+    """
+
+    _inherit = "res.company"
+
+    def stock_accounting_value(self, accounts_by_product=None, at_date=None):
+        """
+        Calcula el valor contable del inventario para la compañía.
+
+        Para compañías padre (con child_ids): delega al super() estándar ya que
+        el override de dominio solo aplica a branches (compañías sin hijos).
+        Para branches (sin child_ids): filtra según shared_to_branches para
+        evitar doble conteo con el padre.
+
+        :param accounts_by_product: dict {product: {valuation: account, ...}}
+                                    Si no se provee, se calcula internamente.
+        :param at_date: fecha de corte para valoración histórica (None = saldo actual)
+        :return: dict {account.account: balance_sum}
+        """
+        if self.child_ids:
+            # La compañía padre delega al comportamiento estándar.
+            # El super() ya consolida sus hijos si corresponde.
+            return super().stock_accounting_value(accounts_by_product=accounts_by_product, at_date=at_date)
+
+        self.ensure_one()
+
+        # Obtener el mapa de cuentas por producto si no fue provisto externamente
+        if not accounts_by_product:
+            accounts_by_product = self._get_accounts_by_product()
+
+        account_data = defaultdict(float)
+
+        # Recolectar todas las cuentas de valoración de stock involucradas
+        stock_valuation_accounts_ids = set()
+        for dummy, accounts in accounts_by_product.items():
+            stock_valuation_accounts_ids.add(accounts["valuation"].id)
+        stock_valuation_accounts = self.env["account.account"].browse(stock_valuation_accounts_ids)
+
+        if self.child_ids:
+            # --- Compañía PADRE ---
+            # Incluir:
+            # a) Sus propios AMLs de productos NO compartidos con branches.
+            # b) Todos los AMLs del grupo (padre + branches) de productos
+            #    compartidos, para consolidar el inventario real en una sola cifra.
+            all_branch_company_ids = self._accessible_branches().ids
+            domain = Domain(
+                [
+                    ("account_id", "in", stock_valuation_accounts.ids),
+                    ("parent_state", "=", "posted"),
+                    "|",
+                    # Rama 1: productos no compartidos → solo asientos propios del padre
+                    "&",
+                    ("product_id.categ_id.shared_to_branches", "!=", True),
+                    ("company_id", "=", self.id),
+                    # Rama 2: productos compartidos → asientos de todo el grupo
+                    "&",
+                    ("product_id.categ_id.shared_to_branches", "=", True),
+                    ("company_id", "in", all_branch_company_ids),
+                ]
+            )
+        else:
+            # --- Compañía BRANCH ---
+            # Incluir solo sus propios AMLs de productos NO compartidos.
+            # Los productos compartidos son responsabilidad del padre; excluirlos
+            # evita inflar la valoración de la branch con stock que físicamente
+            # está en el padre (doble conteo en el reporte de Inventory Valuation).
+            domain = Domain(
+                [
+                    ("account_id", "in", stock_valuation_accounts.ids),
+                    ("parent_state", "=", "posted"),
+                    ("product_id.categ_id.shared_to_branches", "!=", True),
+                    ("company_id", "=", self.id),
+                ]
+            )
+
+        # Aplicar filtro de fecha si se solicita valoración histórica
+        if at_date:
+            domain = domain & Domain([("date", "<=", at_date)])
+
+        # Agrupar AMLs por cuenta y acumular saldos
+        amls_group = self.env["account.move.line"]._read_group(domain, ["account_id"], ["balance:sum"])
+        for account, balance in amls_group:
+            account_data[account] += balance
+
+        return account_data

--- a/stock_account_multicompany_ux/models/stock_move.py
+++ b/stock_account_multicompany_ux/models/stock_move.py
@@ -1,0 +1,131 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_cogs_price_unit(self, quantity=0):
+        """
+        Override: Calcula el precio unitario de COGS usando la valoración de la
+        compañía padre cuando el movimiento pertenece a una branch con categoría
+        de producto marcada como 'shared_to_branches'.
+
+        Cuando una sucursal factura un producto compartido, el costo debe reflejar
+        el inventario real de la compañía padre, no el de la branch (que no posee
+        stock físico propio para esos productos).
+
+        Además, si existe diferencia entre el costo del padre y el de la branch,
+        la registra mediante _log_inventory_cost_difference para que pueda ser
+        usada luego en account_move para generar las líneas de diferencia.
+
+        :param quantity: cantidad en UOM del producto para calcular el costo total
+        :return: precio unitario COGS en la moneda de la compañía
+        """
+        if len(self.product_id) > 1:
+            # Recordset con múltiples productos: no se puede calcular un único precio
+            return 0
+
+        # Identificar la compañía branch y su padre
+        branch_company = self.company_id
+        parent_company = branch_company.parent_id
+
+        # Si no hay compañía padre, esta no es una branch → flujo estándar de Odoo
+        if not parent_company:
+            return super()._get_cogs_price_unit(quantity)
+
+        # Solo interceptar si la categoría tiene 'shared_to_branches' activo.
+        # Para otras categorías, la branch gestiona su propio inventario y costo.
+        if not self.product_id.categ_id.shared_to_branches:
+            return super()._get_cogs_price_unit(quantity)
+
+        # Determinar la cantidad valorada total del recordset
+        move_valued_qty = sum(m._get_valued_qty() for m in self)
+        cogs_qty = quantity or move_valued_qty
+        if not cogs_qty:
+            # Sin cantidad, devolver el precio estándar del padre como referencia
+            return self.product_id.with_company(parent_company).standard_price
+
+        product_parent = self.product_id.with_company(parent_company)
+        product_branch = self.product_id.with_company(branch_company)
+
+        # --- Calcular el precio unitario desde la perspectiva del PADRE ---
+        if product_parent.cost_method == "fifo" or (
+            product_parent.lot_valuated and product_parent.cost_method == "average"
+        ):
+            # FIFO o Average con lotes: buscar movimientos equivalentes en el padre
+            # para calcular el costo ponderado por cantidad.
+            parent_moves = self.env["stock.move"]
+            for move in self:
+                parent_moves |= move._get_parent_company_moves(parent_company)
+
+            if parent_moves:
+                parent_total_qty = sum(m._get_valued_qty() for m in parent_moves)
+                if parent_total_qty:
+                    # Costo promedio ponderado de los movimientos del padre encontrados
+                    parent_price_unit = sum(parent_moves.mapped("value")) / parent_total_qty
+                else:
+                    parent_price_unit = product_parent.standard_price
+            else:
+                # Sin movimientos equivalentes en el padre: caer al precio estándar
+                parent_price_unit = product_parent.standard_price
+        else:
+            # Standard o Average sin lotes: precio estándar vigente del padre
+            parent_price_unit = product_parent.standard_price
+
+        # --- Calcular el precio unitario desde la perspectiva de la BRANCH ---
+        # (necesario para detectar si hay diferencia que registrar)
+        if product_branch.cost_method == "fifo" or (
+            product_branch.lot_valuated and product_branch.cost_method == "average"
+        ):
+            # FIFO/Average con lotes en la branch: usar el valor acumulado de los moves
+            branch_price_unit = sum(self.mapped("value")) / cogs_qty if cogs_qty else product_branch.standard_price
+        else:
+            # Standard/Average: precio estándar de la branch
+            branch_price_unit = product_branch.standard_price
+
+        # --- Registrar diferencia de costos para auditoría y asientos posteriores ---
+        # Si el costo del padre difiere del de la branch, se registra en el contexto
+        # del move para que account_move pueda generar las líneas de diferencia.
+        if not branch_company.currency_id.is_zero(parent_price_unit - branch_price_unit):
+            for move in self:
+                move._log_inventory_cost_difference(parent_price_unit, branch_price_unit, move._get_valued_qty())
+
+        # Retornar siempre el precio del PADRE como COGS de la branch
+        return parent_price_unit
+
+    def _get_parent_company_moves(self, parent_company):
+        """
+        Busca los movimientos de stock equivalentes en la compañía padre para
+        el producto de este move.
+
+        Se usa para calcular el costo FIFO/Average del padre cuando la branch
+        factura un producto compartido. La búsqueda intenta correlacionar el
+        move de la branch con el movimiento de recepción del padre usando el
+        origen del picking o la orden de venta como referencia cruzada.
+
+        :param parent_company: recordset res.company de la compañía padre
+        :return: recordset de stock.move de la compañía padre (puede ser vacío)
+        """
+        self.ensure_one()
+
+        # Buscar movimientos de entrada completados del mismo producto en el padre
+        domain = [
+            ("product_id", "=", self.product_id.id),
+            ("company_id", "=", parent_company.id),
+            ("state", "=", "done"),
+            ("is_in", "=", True),  # solo movimientos de entrada (recepciones, ajustes positivos)
+        ]
+
+        # Refinar la búsqueda usando referencias cruzadas cuando estén disponibles.
+        # El origen del picking (ej. número de PO) o la orden de venta permiten
+        # correlacionar movimientos de la branch con los del padre.
+        if self.picking_id and self.picking_id.origin:
+            domain.append(("picking_id.origin", "=", self.picking_id.origin))
+        elif self.sale_line_id and self.sale_line_id.order_id:
+            domain.append(("sale_line_id.order_id.name", "=", self.sale_line_id.order_id.name))
+
+        # sudo() necesario porque la branch puede no tener acceso directo a los
+        # moves de la compañía padre. Se limita a 10 resultados más recientes.
+        parent_moves = self.env["stock.move"].sudo().search(domain, limit=10, order="date desc")
+
+        return parent_moves

--- a/stock_account_multicompany_ux/views/product_category_views.xml
+++ b/stock_account_multicompany_ux/views/product_category_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_category_form_view_stock_valuation_shared" model="ir.ui.view">
+        <field name="name">product.category.form.stock.valuation.shared.branches</field>
+        <field name="model">product.category</field>
+        <field name="inherit_id" ref="stock_account.view_category_property_form_stock"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='property_valuation']" position="after">
+                <field name="shared_to_branches" groups="base.group_multi_company" invisible="is_branch_company"/>
+                <field name="is_branch_company" invisible="True"/>
+                <div
+                    class="alert alert-info"
+                    role="alert"
+                    colspan="2"
+                    invisible="not shared_to_branches"
+                >
+                    Branches will use the costing method and standard price of the
+                    parent company for this category, ensuring a single unified
+                    cost across all branches.
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION


When a branch company generates an invoice, it now uses the inventory cost from its parent company instead of its own cost.

This ensures consistency in cost accounting across the company hierarchy and allows branches to invoice using centralized inventory valuation.

Features:
- Override stock.move._get_cogs_price_unit() to calculate COGS using parent company's inventory valuation (FIFO, AVCO, or Standard)
- Override account.move.line._get_cogs_value() to use parent's standard price when no stock moves are associated
- Search for equivalent stock moves in parent company by product, origin, or sale order reference
- Log inventory cost differences between branch and parent for audit purposes in ir.logging
- Support all costing methods: FIFO, Average, and Standard Price

Technical:
- Added dependency on stock_account module
- New models: account_move_line.py, stock_move.py
- Extended account_move._stock_account_prepare_realtime_out_lines_vals() for future inventory difference journal entries
- Cost difference logs accessible via Settings > Technical > Logging (filter by name: account_multicompany_ux.inventory_cost_difference)