### PR TITLE
[FIX] account_multicompany_ux: Recompute account_id on move lines after changing company

### DIFF
--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -85,3 +85,4 @@ class AccountChangeCompany(models.TransientModel):
         if old_payment_term and (not old_payment_term.company_id or old_payment_term.company_id == self.company_id):
             vals["invoice_payment_term_id"] = old_payment_term.id
         self.move_id.with_context(skip_invoice_sync=True).write(vals)
+        self.move_id.line_ids._compute_account_id() if self.move_id.line_ids else None


### PR DESCRIPTION


When changing the company of a move, the account_id of its move lines should be recomputed to ensure they are valid for the new company. This is done by calling _compute_account_id on the move lines after writing the new company_id on the move.