### PR TITLE
[ADD] account_multicompany_ux: block inter-company reconciliation option

### DIFF
--- a/account_multicompany_ux/models/res_company.py
+++ b/account_multicompany_ux/models/res_company.py
@@ -17,6 +17,13 @@ class ResCompany(models.Model):
         help="Journal entries are not allowed on consolidation companies. (so invoices, payments, etc neither)"
     )
 
+    block_intercompany_conciliation = fields.Boolean(
+        string="Bloquear conciliación entre diferentes compañías",
+        help="Si está activado, se bloqueará la conciliación entre movimientos "
+        "de diferentes compañías ya sean entre empresas o sucursales.",
+        default=False,
+    )
+
     # TODO habria que terminar de ver si esta bien este cache o en realidad para
     # ser mas performante no hay que usar nada de self
     @tools.ormcache(

--- a/account_multicompany_ux/views/res_company_views.xml
+++ b/account_multicompany_ux/views/res_company_views.xml
@@ -11,6 +11,7 @@
             </div>
             <field name="partner_id" position="after">
                 <field name="consolidation_company"/>
+                <field name="block_intercompany_conciliation" invisible="not child_ids"/>
             </field>
         </field>
     </record>

--- a/account_multicompany_ux/wizards/__init__.py
+++ b/account_multicompany_ux/wizards/__init__.py
@@ -1,1 +1,1 @@
-from . import account_change_company
+from . import account_change_company, account_reconcilice_wizard

--- a/account_multicompany_ux/wizards/account_reconcilice_wizard.py
+++ b/account_multicompany_ux/wizards/account_reconcilice_wizard.py
@@ -1,0 +1,17 @@
+from odoo import models
+from odoo.exceptions import UserError
+
+
+class AccountReconcileWizard(models.TransientModel):
+    _inherit = "account.reconcile.wizard"
+
+    def reconcile(self):
+        for wizard in self:
+            companies = wizard.move_line_ids.mapped("company_id")
+            if len(companies) > 1 and companies.filtered(lambda c: c.child_ids and c.block_intercompany_conciliation):
+                raise UserError(
+                    "Cannot reconcile journal items from different companies. "
+                    "Please verify that the 'Block inter-company reconciliation' option "
+                    "is not enabled in the settings of the companies involved."
+                )
+        return super().reconcile()


### PR DESCRIPTION
Add `block_intercompany_conciliation` boolean field to `res.company` to allow blocking reconciliation between journal items from different companies or branches.

- New field on `res.company`, visible only when the company has child companies (branches).
- Inherit `account.reconcile.wizard` to raise a `UserError` when reconciling move lines from different companies if the flag is enabled on any of the parent companies involved.