### PR TITLE
FIX] account_multicompany_ux: use sudo() when reading shared journal's company fields for get names and currencies

### DIFF
--- a/account_multicompany_ux/models/account_journal.py
+++ b/account_multicompany_ux/models/account_journal.py
@@ -17,9 +17,10 @@ class AccountJournal(models.Model):
         nativo de odoo
         """
         for journal in self:
-            currency = journal.currency_id or journal.company_id.currency_id
-            if journal.company_id.get_company_sufix():
-                name = f"{journal.name} ({currency.name}) {journal.company_id.get_company_sufix()}"
+            company = journal.company_id.sudo()
+            currency = journal.currency_id or company.currency_id
+            if company.get_company_sufix():
+                name = f"{journal.name} ({currency.name}) {company.get_company_sufix()}"
                 journal.display_name = name
             else:
                 super()._compute_display_name()


### PR DESCRIPTION
    Branch users can read journals from a parent company via the
    shared_to_branches rule in account_ux, but base.res_company_rule_employee
    still blocks reading that company's record directly. Any code that does
    journal.company_id.FIELD raises AccessError for those users.
