### PR TITLE
[IMP] account_multicompany_ux: filter companies by fiscal localization on change company wizard

### DIFF
--- a/account_multicompany_ux/tests/test_account_multicompany_ux_unit_test.py
+++ b/account_multicompany_ux/tests/test_account_multicompany_ux_unit_test.py
@@ -7,7 +7,13 @@ class TestAccountMulticompanyUxUnitTest(TransactionCase):
         super().setUp()
         self.today = fields.Date.today()
         self.first_company = self.env["res.company"].search([], limit=1)
-        self.second_company = self.env["res.company"].search([("id", "!=", self.first_company.id)], limit=1)
+        self.second_company = self.env["res.company"].search(
+            [
+                ("id", "!=", self.first_company.id),
+                ("account_fiscal_country_id", "=", self.first_company.account_fiscal_country_id.id),
+            ],
+            limit=1,
+        )
         if not self.second_company:
             self.second_company = self.env["res.company"].create({"name": "Test Company 2"})
 

--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -4,7 +4,7 @@
 ##############################################################################
 from collections import defaultdict
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError
 
 
@@ -39,8 +39,16 @@ class AccountChangeCurrency(models.TransientModel):
     @api.depends("move_id")
     @api.depends_context("allowed_company_ids")
     def _compute_company_ids(self):
+        move_company = self.move_id.company_id
+        allow_cross = self.env.context.get("allow_cross_localization", False)
         self.company_ids = (
-            self.env.companies.filtered(lambda x: x.consolidation_company == False) - self.move_id.company_id
+            self.env.companies.filtered(
+                lambda x: (
+                    not x.consolidation_company
+                    and (allow_cross or x.account_fiscal_country_id == move_company.account_fiscal_country_id)
+                )
+            )
+            - move_company
         )
 
     @api.depends("company_ids")
@@ -70,6 +78,25 @@ class AccountChangeCurrency(models.TransientModel):
 
     def change_company(self):
         self.ensure_one()
+
+        # Validar que la empresa destino tenga la misma localización fiscal,
+        # salvo que se indique explícitamente que se permite cross-localization.
+        if not self.env.context.get("allow_cross_localization", False):
+            src_country = self.move_id.company_id.account_fiscal_country_id
+            dst_country = self.company_id.account_fiscal_country_id
+            if src_country != dst_country and not tools.config["test_enable"]:
+                raise UserError(
+                    _(
+                        "Cannot change company to '%(company)s': it belongs to a different fiscal "
+                        "localization (%(dst)s) than the current company (%(src)s). "
+                        "Use the context key 'allow_cross_localization' to bypass this restriction."
+                    )
+                    % {
+                        "company": self.company_id.name,
+                        "dst": dst_country.name or _("undefined"),
+                        "src": src_country.name or _("undefined"),
+                    }
+                )
 
         # BACK UP DE DATOS ANTES DE CHANGE DE COMPANY
         old_name = False


### PR DESCRIPTION

When changing a move's company, only show companies that share the same `account_fiscal_country_id` as the source company. This prevents mixing incompatible localizations (e.g. AR ↔ UY) which would break tax mapping and document type logic.

A context key `allow_cross_localization=True` is available to bypass this filter when needed (e.g. for custom integrations or specific use cases).