### PR TITLE
[FIX] website_sale_multic_ux: fix TypeError en checkout de usuario público

### DIFF
--- a/website_sale_multic_ux/controllers/main.py
+++ b/website_sale_multic_ux/controllers/main.py
@@ -2,7 +2,7 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class WebsiteSale(WebsiteSale):
-    def _complete_address_values(self, address_values, address_type, use_delivery_as_billing, order_sudo):
-        super()._complete_address_values(address_values, address_type, use_delivery_as_billing, order_sudo)
-        if order_sudo._is_anonymous_cart():
+    def _complete_address_values(self, address_values, *args, order_sudo=False, **kwargs):
+        super()._complete_address_values(address_values, *args, order_sudo=order_sudo, **kwargs)
+        if order_sudo and order_sudo._is_anonymous_cart():
             address_values["company_id"] = False


### PR DESCRIPTION
## Problema

Al hacer checkout como usuario público en el e-commerce de Odoo 19,  devolvía HTTP 500 con:

```
TypeError: WebsiteSale._complete_address_values() got an unexpected keyword argument 'name'
```

En Odoo 19, `portal.py:542` (`_create_or_update_address`) llama a `_complete_address_values` con el kwarg `name`, que no existía en versiones anteriores. El override de `website_sale_multic_ux` no tenía `**kwargs` y explotaba antes de poder devolver JSON, retornando HTML 500 al cliente.

## Fix

Agregar `**kwargs` a la firma del método y pasarlos al `super()`.

## Testing

- Reproducido en `test-pacifictrailers-04-06-1.adhoc.inc`
- Con el fix: `/shop/address/submit` devuelve JSON correctamente y el checkout de usuario público funciona