### PR TITLE
[FIX] account_multicompany_ux: preserve down payment sale line taxes …

### DIFF
--- a/account_multicompany_ux/tests/test_account_multicompany_ux_unit_test.py
+++ b/account_multicompany_ux/tests/test_account_multicompany_ux_unit_test.py
@@ -208,3 +208,123 @@ class TestAccountMulticompanyUxUnitTest(TransactionCase):
 
         customer_invoice.action_post()
         vendor_bill.action_post()
+
+    def test_downpayment_taxes_preserved_on_company_change(self):
+        """Al cambiar la compañía de una factura de anticipo con 2 alícuotas de IVA,
+        las sale.order.line de anticipo deben conservar sus impuestos originales (21% y 10.5%)
+        y no colapsar al impuesto único del producto de anticipo (bug: #120730)."""
+        # Crear dos impuestos con distinto amount en first_company
+        tax_21 = self.env["account.tax"].search(
+            [("company_id", "=", self.first_company.id), ("type_tax_use", "=", "sale"), ("amount", "=", 21)],
+            limit=1,
+        )
+        if not tax_21:
+            tax_21 = (
+                self.env["account.tax"]
+                .with_company(self.first_company)
+                .create({"name": "IVA 21% Test", "amount": 21, "type_tax_use": "sale"})
+            )
+
+        tax_105 = self.env["account.tax"].search(
+            [("company_id", "=", self.first_company.id), ("type_tax_use", "=", "sale"), ("amount", "=", 10.5)],
+            limit=1,
+        )
+        if not tax_105:
+            tax_105 = (
+                self.env["account.tax"]
+                .with_company(self.first_company)
+                .create({"name": "IVA 10.5% Test", "amount": 10.5, "type_tax_use": "sale"})
+            )
+
+        # Impuesto equivalente en second_company (necesario para que el wizard no falle al mapear)
+        for tax in [tax_21, tax_105]:
+            equiv = self.env["account.tax"].search(
+                [
+                    ("company_id", "=", self.second_company.id),
+                    ("type_tax_use", "=", "sale"),
+                    ("amount", "=", tax.amount),
+                ],
+                limit=1,
+            )
+            if not equiv:
+                self.env["account.tax"].with_company(self.second_company).create(
+                    {"name": tax.name + " (C2)", "amount": tax.amount, "type_tax_use": "sale"}
+                )
+
+        # Dos productos con distintas alícuotas
+        product_a = self.env["product.product"].create(
+            {"name": "Producto A (21%)", "taxes_id": [Command.set(tax_21.ids)]}
+        )
+        product_b = self.env["product.product"].create(
+            {"name": "Producto B (10.5%)", "taxes_id": [Command.set(tax_105.ids)]}
+        )
+
+        # Orden de venta con ambos productos
+        sale_order = (
+            self.env["sale.order"]
+            .with_company(self.first_company)
+            .create(
+                {
+                    "partner_id": self.partner_ri.id,
+                    "company_id": self.first_company.id,
+                    "order_line": [
+                        Command.create({"product_id": product_a.id, "product_uom_qty": 1, "price_unit": 1000}),
+                        Command.create({"product_id": product_b.id, "product_uom_qty": 1, "price_unit": 500}),
+                    ],
+                }
+            )
+        )
+        sale_order.action_confirm()
+
+        # Facturar anticipo del 50%
+        advance_wizard = (
+            self.env["sale.advance.payment.inv"]
+            .with_context(active_ids=sale_order.ids, active_model="sale.order")
+            .create({"advance_payment_method": "percentage", "amount": 50})
+        )
+        advance_wizard.create_invoices()
+
+        # Verificar que se crearon líneas de anticipo con ambas alícuotas
+        dp_lines = sale_order.order_line.filtered(lambda l: l.is_downpayment and not l.display_type)
+        dp_tax_amounts = sorted(dp_lines.mapped("tax_id.amount"))
+        self.assertEqual(
+            len(dp_lines),
+            2,
+            "Deben existir 2 líneas de anticipo (una por combinación de impuesto)",
+        )
+        self.assertIn(21.0, dp_tax_amounts, "Debe haber una línea de anticipo con IVA 21%")
+        self.assertIn(10.5, dp_tax_amounts, "Debe haber una línea de anticipo con IVA 10.5%")
+
+        # Obtener la factura de anticipo
+        advance_invoice = sale_order.invoice_ids[:1]
+        self.assertTrue(advance_invoice, "Debe haberse creado la factura de anticipo")
+
+        # Cambiar compañía de la factura de anticipo
+        wizard = self.env["account.change.company"].create(
+            {
+                "move_id": advance_invoice.id,
+                "company_ids": [self.first_company.id, self.second_company.id],
+                "company_id": self.second_company.id,
+                "journal_id": self.second_company_journal.id,
+            }
+        )
+        wizard.change_company()
+
+        # Verificar que las líneas de anticipo de la VENTA conservan sus impuestos originales
+        dp_lines_after = sale_order.order_line.filtered(lambda l: l.is_downpayment and not l.display_type)
+        dp_tax_amounts_after = sorted(dp_lines_after.mapped("tax_id.amount"))
+        self.assertEqual(
+            len(dp_lines_after),
+            2,
+            "Deben seguir existiendo 2 líneas de anticipo tras el cambio de compañía",
+        )
+        self.assertIn(
+            21.0,
+            dp_tax_amounts_after,
+            "La línea de anticipo con IVA 21% debe conservar su alícuota tras el cambio de compañía",
+        )
+        self.assertIn(
+            10.5,
+            dp_tax_amounts_after,
+            "La línea de anticipo con IVA 10.5% debe conservar su alícuota (no colapsar al 21%)",
+        )

--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -135,6 +135,15 @@ class AccountChangeCurrency(models.TransientModel):
         # asignación individual (account_id, tax_ids, etc.) dispare _sync_dynamic_lines del move.
         # La sincronización ocurre una sola vez al final, fuera de este contexto.
         move = self.move_id
+
+        # Backup del tax_id de las sale.order.line de anticipo ANTES de modificar la factura.
+        # El proceso del wizard dispara el recompute de _compute_tax_id sobre estas líneas, que
+        # colapsa todas al impuesto único del producto de anticipo (perdiendo alícuotas múltiples,
+        # p.ej. una OV con 21% + 10.5% queda con solo 21% y la factura final no puede cerrarse).
+        # La OV no cambia de compañía → los impuestos originales de cada línea siguen siendo válidos.
+        dp_sale_lines = move.invoice_line_ids.sale_line_ids.filtered(lambda l: l.is_downpayment and not l.display_type)
+        original_dp_sale_taxes = {sol.id: sol.tax_id.ids[:] for sol in dp_sale_lines}
+
         move.invoice_line_ids.tax_ids = False
 
         # si el payment term tiene compañía y es distinta a la que elegimos, forzamos recomputo
@@ -217,6 +226,15 @@ class AccountChangeCurrency(models.TransientModel):
         container = {"records": self.move_id}
         with self.move_id._check_balanced(container), self.move_id._sync_dynamic_lines(container):
             pass
+
+        # Restaurar tax_id de las sale.order.line de anticipo.
+        # El _sync_dynamic_lines de arriba (y las operaciones previas del wizard) disparan el
+        # recompute de _compute_tax_id que colapsa todas las líneas al impuesto único del producto
+        # de anticipo. Restauramos los valores originales por línea para preservar alícuotas múltiples.
+        for sol in dp_sale_lines:
+            taxes_to_restore = original_dp_sale_taxes.get(sol.id)
+            if taxes_to_restore is not None:
+                sol.tax_id = [(6, 0, taxes_to_restore)]
 
     def _sync_lines_balance_from_amount_currency(self, move):
         """Alinea balance con amount_currency para soportar cambio de compañía entre monedas."""


### PR DESCRIPTION
…on company change

When changing the company of a down payment invoice, the wizard triggered a recompute of _compute_tax_id on the related sale.order.line records with is_downpayment=True. Since all down payment lines share the same advance payment product (which has a single default tax), the recompute collapsed all lines to that single tax, losing additional rate lines (e.g. 10.5% IVA alongside 21% IVA), which prevented generating the final invoice.

Fix: capture the original tax_id of down payment sale lines before any changes, and restore them after _sync_dynamic_lines completes.