### PR TITLE
[ADD] stock_account_multicompany_ux: branch-aware 'manage multiple warehouses' permission

### DIFF
--- a/stock_account_multicompany_ux/README.rst
+++ b/stock_account_multicompany_ux/README.rst
@@ -46,6 +46,14 @@ Features
   difference between the branch cost and the parent cost to the appropriate
   inventory difference account when real-time valuation is active.
 
+- **Branch-aware "Manage Multiple Warehouses" permission** (``stock.warehouse``):
+  overrides ``_check_multiwarehouse_group()`` so the warehouse count is grouped
+  by the **root company** (``company_id.root_id``) instead of by each individual
+  company. This way warehouses belonging to a parent company and its branches are
+  summed together, and the ``stock.group_stock_multi_warehouses`` permission is
+  auto-enabled/disabled based on the whole group. Companies without branches keep
+  the standard behaviour (``root_id`` is the company itself).
+
 Installation
 ============
 

--- a/stock_account_multicompany_ux/__manifest__.py
+++ b/stock_account_multicompany_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock Account Multicompany Usability",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/stock_account_multicompany_ux/models/__init__.py
+++ b/stock_account_multicompany_ux/models/__init__.py
@@ -3,3 +3,4 @@ from . import stock_move
 from . import product_category
 from . import account_move
 from . import res_company
+from . import stock_warehouse

--- a/stock_account_multicompany_ux/models/stock_warehouse.py
+++ b/stock_account_multicompany_ux/models/stock_warehouse.py
@@ -1,0 +1,68 @@
+from collections import defaultdict
+
+from odoo import models
+
+
+class StockWarehouse(models.Model):
+    _inherit = "stock.warehouse"
+
+    def _warehouse_count_by_root_company(self):
+        """Cantidad de almacenes activos agrupada por compañía raíz.
+
+        El core cuenta agrupando por ``company_id``. Acá sumamos los almacenes
+        de las sucursales (branches) al de su compañía padre usando
+        ``company_id.root_id`` (la compañía tope de la jerarquía). Para
+        compañías sin sucursales ``root_id`` es la propia compañía, por lo que
+        el conteo coincide con el estándar.
+
+        :return: dict {res.company (raíz): cantidad de almacenes del grupo}
+        """
+        cnt_by_company = self.env["stock.warehouse"].sudo()._read_group(
+            [("active", "=", True)], ["company_id"], aggregates=["__count"]
+        )
+        cnt_by_root = defaultdict(int)
+        for company, count in cnt_by_company:
+            cnt_by_root[company.root_id] += count
+        return cnt_by_root
+
+    def _check_multiwarehouse_group(self):
+        """Contempla sucursales (branches) al auto-activar el permiso
+        "Gestionar varios almacenes" (``stock.group_stock_multi_warehouses``).
+
+        El core agrupa los almacenes activos por ``company_id`` y activa el
+        permiso cuando alguna compañía tiene más de un almacén. Con el modelo
+        de sucursales (cada branch es una compañía hija con su propio almacén),
+        el padre y cada branch quedan con un único almacén, por lo que el
+        conteo por compañía nunca supera 1 y el permiso no se activa solo.
+
+        Reescribimos el conteo agrupando por la compañía raíz
+        (ver :meth:`_warehouse_count_by_root_company`), de modo que los
+        almacenes del grupo (padre + sucursales) se sumen.
+        """
+        cnt_by_root = self._warehouse_count_by_root_company()
+        if not cnt_by_root:
+            return
+
+        max_count = max(cnt_by_root.values())
+
+        group_user = self.env.ref("base.group_user")
+        group_stock_multi_warehouses = self.env.ref("stock.group_stock_multi_warehouses")
+        group_stock_multi_locations = self.env.ref("stock.group_stock_multi_locations")
+        if max_count <= 1 and group_stock_multi_warehouses in group_user.implied_ids:
+            group_user.write({"implied_ids": [(3, group_stock_multi_warehouses.id)]})
+            group_stock_multi_warehouses.write(
+                {"user_ids": [(3, user.id) for user in group_user.all_user_ids]}
+            )
+        if max_count > 1 and group_stock_multi_warehouses not in group_user.implied_ids:
+            if group_stock_multi_locations not in group_user.implied_ids:
+                self.env["res.config.settings"].create(
+                    {"group_stock_multi_locations": True}
+                ).execute()
+            group_user.write(
+                {
+                    "implied_ids": [
+                        (4, group_stock_multi_warehouses.id),
+                        (4, group_stock_multi_locations.id),
+                    ]
+                }
+            )

--- a/stock_account_multicompany_ux/tests/__init__.py
+++ b/stock_account_multicompany_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_multiwarehouse_group

--- a/stock_account_multicompany_ux/tests/test_multiwarehouse_group.py
+++ b/stock_account_multicompany_ux/tests/test_multiwarehouse_group.py
@@ -1,0 +1,73 @@
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestMultiwarehouseGroup(TransactionCase):
+    """Auto-activado del permiso "Gestionar varios almacenes" contemplando
+    sucursales (branches).
+
+    En modo test, crear una ``res.company`` auto-crea un almacén
+    (``stock/models/res_company.py``), por lo que cada compañía creada acá
+    arranca con exactamente un almacén.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.Warehouse = self.env["stock.warehouse"]
+        self.group_user = self.env.ref("base.group_user")
+        self.group_multi_wh = self.env.ref("stock.group_stock_multi_warehouses")
+        self.parent_company = self.env["res.company"].create({"name": "Casa Central Test"})
+        self.branch_company = self.env["res.company"].create(
+            {"name": "Sucursal Test", "parent_id": self.parent_company.id}
+        )
+
+    def test_root_company_is_parent_for_branch(self):
+        """La sucursal comparte la compañía raíz con el padre."""
+        self.assertEqual(self.parent_company.root_id, self.parent_company)
+        self.assertEqual(self.branch_company.root_id, self.parent_company)
+
+    def test_warehouse_count_groups_branch_under_root(self):
+        """El almacén de la sucursal se suma al de la compañía raíz.
+
+        Es el núcleo del fix: el core contaría 1 almacén por compañía
+        (padre y branch por separado); acá ambos deben acumularse bajo la
+        raíz, dando 2.
+        """
+        parent_whs = self.Warehouse.search([("company_id", "=", self.parent_company.id)])
+        branch_whs = self.Warehouse.search([("company_id", "=", self.branch_company.id)])
+        self.assertEqual(len(parent_whs), 1)
+        self.assertEqual(len(branch_whs), 1)
+
+        cnt_by_root = self.Warehouse._warehouse_count_by_root_company()
+        self.assertEqual(
+            cnt_by_root[self.parent_company],
+            2,
+            "El almacén de la sucursal debe sumarse al de la compañía raíz",
+        )
+
+    def test_branch_warehouse_activates_multiwarehouse_group(self):
+        """Crear una sucursal con almacén auto-activa el permiso.
+
+        Al crearse el almacén de la sucursal se dispara
+        ``_check_multiwarehouse_group``; como el grupo raíz pasa a tener 2
+        almacenes, el permiso debe quedar implícito en el grupo base.
+        """
+        self.assertIn(
+            self.group_multi_wh,
+            self.group_user.implied_ids,
+            "El permiso 'Gestionar varios almacenes' debe activarse al haber "
+            "una sucursal con almacén bajo la misma compañía raíz",
+        )
+
+    def test_archiving_branch_warehouse_recounts_root(self):
+        """Al archivar el almacén de la sucursal, la raíz vuelve a contar 1."""
+        branch_wh = self.Warehouse.search([("company_id", "=", self.branch_company.id)])
+        branch_wh.action_archive()
+
+        cnt_by_root = self.Warehouse._warehouse_count_by_root_company()
+        self.assertEqual(
+            cnt_by_root[self.parent_company],
+            1,
+            "Tras archivar el almacén de la sucursal, la raíz debe contar solo "
+            "el almacén del padre",
+        )


### PR DESCRIPTION
Task #69369

## Problem

The core auto-enables `stock.group_stock_multi_warehouses` (the "Manage multiple warehouses" user permission) by counting active warehouses grouped by `company_id` in `stock.warehouse._check_multiwarehouse_group()`.

With the branches model (each branch is a child company with its own warehouse), a parent company with one warehouse and a branch with one warehouse each count as 1 per company, so the per-company maximum never exceeds 1 and the permission is never enabled automatically — even though the group as a whole operates several warehouses.

## Change

Override `_check_multiwarehouse_group()` on `stock.warehouse` so the warehouse count is grouped by the **root company** (`company_id.root_id`) instead of by each individual company. Warehouses of a parent and its branches are summed together, and the permission is auto-enabled/disabled based on the whole company tree.

The counting is extracted into a small helper `_warehouse_count_by_root_company()` for testability. Companies without branches keep the standard behaviour, since `root_id` is the company itself.

## Test plan

New `tests/test_multiwarehouse_group.py` (4 tests, all green):

- a branch shares its root company with the parent;
- the branch warehouse is summed under the root company count (core would count 1 per company; grouped by root it is 2);
- creating a branch with a warehouse auto-enables the permission;
- archiving the branch warehouse re-counts the root down to 1.

Run:

```
odoo -d <db> -i stock_account_multicompany_ux --test-enable --test-tags /stock_account_multicompany_ux
```