### PR TITLE
[IMP] stock_account_multicompany_ux: share parent cost to branches

### DIFF
--- a/stock_account_multicompany_ux/__manifest__.py
+++ b/stock_account_multicompany_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock Account Multicompany Usability",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",

--- a/stock_account_multicompany_ux/migrations/19.0.1.1.0/post-migration.py
+++ b/stock_account_multicompany_ux/migrations/19.0.1.1.0/post-migration.py
@@ -1,0 +1,20 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Activa shared_to_branches en las categorías automatizadas (real_time)
+    presentes en padre y branches (setups A/B migrados sin el flag).
+
+    La lógica vive en product.category.activate_shared_to_branches_for_ab para
+    poder reutilizarse también desde la UL 2379.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    activated = env["product.category"].activate_shared_to_branches_for_ab()
+    _logger.info(
+        "stock_account_multicompany_ux: shared_to_branches activado en %s categorías A/B",
+        len(activated),
+    )

--- a/stock_account_multicompany_ux/models/product_category.py
+++ b/stock_account_multicompany_ux/models/product_category.py
@@ -74,6 +74,13 @@ class ProductCategory(models.Model):
             parent_cost_method = categ.with_company(parent_company).property_cost_method
             parent_valuation = categ.with_company(parent_company).property_valuation
 
+            # Productos de la categoría cuyo costo (standard_price, campo
+            # company-dependent) se unifica con el del padre.
+            products = self.env["product.product"].with_context(active_test=False).search([("categ_id", "=", categ.id)])
+            parent_cost_by_product = {
+                product.id: product.with_company(parent_company).standard_price for product in products
+            }
+
             # Escribir la misma configuración en el contexto de cada branch
             for branch in branches:
                 categ.with_company(branch).write(
@@ -82,6 +89,60 @@ class ProductCategory(models.Model):
                         "property_valuation": parent_valuation,
                     }
                 )
+
+                # Traer el costo del padre a la branch SIN revaluar: usamos el
+                # contexto disable_auto_revaluation para no generar SVL ni asiento
+                # contable en la branch. Esto es coherente con que el módulo ya
+                # excluye estos productos de la valoración de la branch
+                # (ver res.company.stock_accounting_value); el inventario y su
+                # valoración viven en el padre, la branch solo refleja el costo.
+                for product in products:
+                    product.with_company(branch).with_context(
+                        disable_auto_revaluation=True
+                    ).standard_price = parent_cost_by_product[product.id]
+
+    @api.model
+    def activate_shared_to_branches_for_ab(self):
+        """Activa 'shared_to_branches' en las categorías cuya valoración es
+        automatizada (real_time) tanto en la compañía padre como en sus branches.
+
+        Pensado para correr post-migración en setups A/B (company merge): la
+        migración deja esas categorías sin el flag tildado, lo que impide que el
+        costo se comparta padre↔branches. Este método detecta los casos y activa
+        el flag desde el contexto del padre, disparando la propagación de
+        método de costeo, valoración y costo hacia las branches.
+
+        Método público a propósito: además del post-migration del módulo, lo
+        invoca por RPC (odooly) la UL 2379 ("Shared to branches en Valoración
+        automatica de stock con A y B"). RPC bloquea métodos con guion bajo.
+
+        Criterio: la categoría es 'real_time' leída en el contexto del padre y
+        en al menos una de sus branches.
+
+        :return: recordset de product.category activadas
+        """
+        parents = self.env["res.company"].search([("parent_id", "=", False), ("child_ids", "!=", False)])
+        categories = self.with_context(active_test=False).search([])
+        activated = self.browse()
+        for parent in parents:
+            branches = parent._accessible_branches() - parent
+            if not branches:
+                continue
+            for categ in categories:
+                if categ.shared_to_branches:
+                    continue
+                # Automatizada en el padre...
+                if categ.with_company(parent).property_valuation != "real_time":
+                    continue
+                # ...y en al menos una branch.
+                if not any(categ.with_company(branch).property_valuation == "real_time" for branch in branches):
+                    continue
+                # Activar desde el contexto del padre: el write dispara
+                # _propagate_valuation_to_branches, que copia costeo/valoración y
+                # trae el costo del padre a las branches.
+                categ.with_company(parent).shared_to_branches = True
+                activated |= categ
+        return activated
 
     @api.depends_context("company")
     def _compute_is_branch_company(self):


### PR DESCRIPTION
## What

When a product category has **Shared Stock Valuation to Branches** enabled, the propagation from the parent company to its branches now also includes the **cost** (`standard_price`) of the category's products — not only the costing method and valuation.

The cost is written in each branch context with `disable_auto_revaluation=True`, so it does **not** create stock valuation layers nor accounting entries in the branch. This is consistent with the module already excluding shared-category products from the branch valuation (`res.company.stock_accounting_value`): the inventory and its valuation live in the parent, the branch only mirrors the cost.

## Why

The field help already stated that branches use *"the costing method and standard price defined in the parent company"*, but only the costing method and valuation were being propagated — the standard price was left out, so the branch product card kept its own (possibly empty) cost while COGS used the parent's.

## Also added

`product.category._activate_shared_to_branches_for_ab()` — a reusable helper that enables `shared_to_branches` on categories whose valuation is `real_time` in both the parent company and at least one of its branches. Useful for parent/branch (company merge) setups where the flag ends up unset. It is invoked from a new post-migration (`19.0.1.1.0`) and can be reused by external upgrade scripts.

## Test

- On a parent/branch setup, enable `shared_to_branches` on an automated-valuation category and check the branch products take the parent `standard_price` without generating revaluation entries in the branch.
- Run the module upgrade on a parent/branch DB and verify automated categories present in both companies get the flag enabled.