### PR TITLE
[FIX] account_multicompany_ux: recover report from active_id to avoid singleton on company switch

### DIFF
--- a/account_multicompany_ux/models/account_report.py
+++ b/account_multicompany_ux/models/account_report.py
@@ -2,11 +2,43 @@
 # For copyright and license notices, see __manifest__.py file in module root
 # directory
 ##############################################################################
-from odoo import models
+from odoo import api, models
 
 
 class AccountReport(models.Model):
     _inherit = "account.report"
+
+    @api.readonly
+    def get_options(self, previous_options):
+        """Recuperar el reporte cuando se pierde el ``report_id`` del contexto.
+
+        Cuando un reporte se abre desde una declaración (``account.return``) y
+        luego se cambia la selección de compañías con el reporte abierto, el
+        switch global de compañías dispara una recarga completa de página. Al
+        restaurar la acción cliente, el framework reconstruye el contexto como
+        ``{'active_id': <return_id>}`` y descarta el ``report_id``, por lo que
+        este método se ejecuta sobre un recordset vacío y ``ensure_one()``
+        revienta con ``Expected singleton: account.report()``. Recuperamos el
+        reporte desde la declaración apuntada por ``active_id``. Ver ticket
+        121344.
+
+        Solo recuperamos si el ``active_model`` está ausente (caso del bug, donde
+        el framework deja el contexto en ``{'active_id'}``) o es explícitamente
+        ``account.return``; así evitamos resolver un ``account.return`` por
+        casualidad cuando ``active_id`` pertenece a otro modelo con id solapado.
+
+        El chequeo ``"account.return" in self.env`` cubre instalaciones donde ese
+        modelo no esté disponible: en ese caso degradamos al comportamiento de
+        ``super()`` (el ``ensure_one()`` original) en vez de romper con KeyError.
+        """
+        if not self and "account.return" in self.env:
+            active_id = self.env.context.get("active_id")
+            active_model = self.env.context.get("active_model")
+            if active_id and active_model in (None, False, "account.return"):
+                account_return = self.env["account.return"].browse(active_id).exists()
+                if account_return.type_id.report_id:
+                    self = account_return.type_id.report_id
+        return super().get_options(previous_options)
 
     def _expand_unfoldable_line(
         self,


### PR DESCRIPTION
## Problema

Al abrir un reporte impositivo desde una declaración (`account.return`) y luego cambiar la selección de compañías con el reporte abierto, el switch global de compañías dispara una recarga completa de página. Al restaurar la acción cliente, el framework web reconstruye el contexto como `{'active_id': <return_id>}` y descarta el `report_id`. Como consecuencia `account.report.get_options` se ejecuta sobre un recordset vacío y `ensure_one()` revienta:

```
ValueError: Expected singleton: account.report()
```

Reproduce para cualquier reporte abierto desde el botón de una declaración + cambio de selección de compañías.

## Causa raíz

- El reporte se abre con `account.return.action_open_report()`, que devuelve una acción cliente con el `report_id` únicamente en el `context`.
- El switch de compañías hace `pushState(..., {reload: true})` → recarga completa.
- Al restaurar la acción, el framework reconstruye el `context` como `{active_id}` y pierde el `report_id`. Tras la recarga el `report_id` tampoco se recupera por `params` ni por `sessionStorage` (la clave de sesión se arma con el `actionReportId`, que también queda vacío). El único dato que sobrevive es `active_id` (la declaración).

## Solución

Override de `account.report.get_options` en `account_multicompany_ux` (módulo natural por ser donde vive la lógica del switch multi-compañía): si `self` está vacío, se recupera el reporte desde la declaración apuntada por `context['active_id']` (`account.return.type_id.report_id`). Si no hay nada que recuperar, se mantiene el comportamiento original.

Fix mínimo y defensivo, sin tocar código enterprise.

Ticket: https://www.adhoc.inc/odoo/action-helpdesk.helpdesk_ticket_action_main_tree/121344