### PR TITLE
[FIX] account_multicompany_ux: Avoid sync when recompute fiscal position

### DIFF
--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -208,7 +208,7 @@ class AccountChangeCurrency(models.TransientModel):
         self._get_change_company_line_taxes(move.invoice_line_ids, original_taxes)
         # para percepciones argentinas re-computamos con su propio método
         if move.fiscal_position_id._fields.get("l10n_ar_tax_ids"):
-            move._l10n_ar_recompute_fiscal_position_taxes()
+            move.with_context(skip_invoice_sync=True)._l10n_ar_recompute_fiscal_position_taxes()
 
         # PARTNER BANK
         if original_partner_bank_id and original_partner_bank_id.company_id.id in [False, self.company_id.id]:


### PR DESCRIPTION
  When recomputing AR perception taxes on a sale document, taxes were
  assigned one line at a time inside a loop. Each `line.tax_ids = ...`
  (and `line.tax_id = ...` on sale.order) assignment triggers the move's
  full `_sync_dynamic_lines` recompute, making the whole operation O(N²)
  on the number of lines. On invoices generated from long orders this
  exhausts the worker memory and the invoice cannot be created.

  Group the lines by their current tax combination and write once per
  group, mirroring the batching already used in
  `account_change_company._get_change_company_line_taxes`. This turns the
  N per-line syncs into k syncs (k = distinct tax combinations, typically
  1-3), keeping memory bounded.

  Also let `account_change_company.change_company` invoke the recompute
  Also let `account_change_company.change_company` invoke the recompute
  with `skip_invoice_sync=True`: the wizard already runs a single
  `_sync_dynamic_lines` at the end, so no intermediate sync is needed
  during the perception recompute.
  Also let `account_change_company.change_company` invoke the recompute
  with `skip_invoice_sync=True`: the wizard already runs a single
  `_sync_dynamic_lines` at the end, so no intermediate sync is needed
  during the perception recompute.