### PR TITLE
[FIX] account_multicompany_ux: allow switching to sibling branches in Change Company wizard

### DIFF
--- a/account_multicompany_ux/tests/__init__.py
+++ b/account_multicompany_ux/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_account_change_company
 from . import test_account_multicompany_ux_unit_test

--- a/account_multicompany_ux/tests/test_account_change_company.py
+++ b/account_multicompany_ux/tests/test_account_change_company.py
@@ -1,0 +1,121 @@
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountChangeCompany(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.parent_company = cls.env["res.company"].create({"name": "Casa Matriz Test"})
+        cls.branch_a = cls.env["res.company"].create(
+            {"name": "Sucursal Centro Test", "parent_id": cls.parent_company.id}
+        )
+        cls.branch_b = cls.env["res.company"].create(
+            {"name": "Sucursal Norte Test", "parent_id": cls.parent_company.id}
+        )
+        cls.branch_a_child = cls.env["res.company"].create({"name": "Centro AUX Test", "parent_id": cls.branch_a.id})
+
+        cls.env.user.write(
+            {
+                "company_ids": [
+                    (4, c.id) for c in (cls.parent_company + cls.branch_a + cls.branch_b + cls.branch_a_child)
+                ]
+            }
+        )
+
+        income_account = cls.env["account.account"].create(
+            {
+                "code": "X9100",
+                "name": "Branch A Income - (test)",
+                "account_type": "income",
+                "company_ids": [cls.branch_a.id],
+            }
+        )
+        branch_a_journal = cls.env["account.journal"].create(
+            {
+                "name": "Branch A Invoices - Test",
+                "code": "BAINV",
+                "type": "sale",
+                "default_account_id": income_account.id,
+                "company_id": cls.branch_a.id,
+            }
+        )
+        cls.move = (
+            cls.env["account.move"]
+            .with_company(cls.branch_a)
+            .create(
+                {
+                    "move_type": "out_invoice",
+                    "company_id": cls.branch_a.id,
+                    "journal_id": branch_a_journal.id,
+                }
+            )
+        )
+
+        grandchild_income_account = cls.env["account.account"].create(
+            {
+                "code": "X9200",
+                "name": "Centro AUX Income - (test)",
+                "account_type": "income",
+                "company_ids": [cls.branch_a_child.id],
+            }
+        )
+        grandchild_journal = cls.env["account.journal"].create(
+            {
+                "name": "Centro AUX Invoices - Test",
+                "code": "GCINV",
+                "type": "sale",
+                "default_account_id": grandchild_income_account.id,
+                "company_id": cls.branch_a_child.id,
+            }
+        )
+        cls.grandchild_move = (
+            cls.env["account.move"]
+            .with_company(cls.branch_a_child)
+            .create(
+                {
+                    "move_type": "out_invoice",
+                    "company_id": cls.branch_a_child.id,
+                    "journal_id": grandchild_journal.id,
+                }
+            )
+        )
+
+    def _wizard_company_ids(self, allowed_companies, move=None):
+        wizard = (
+            self.env["account.change.company"]
+            .with_context(active_id=(move or self.move).id, allowed_company_ids=allowed_companies.ids)
+            .new({})
+        )
+        return wizard.company_ids._origin
+
+    def test_sibling_company_is_listed(self):
+        """Parado en una sucursal, el wizard debe ofrecer tanto la casa matriz
+        como las sucursales hermanas, no solo la matriz (tarea #70688)."""
+        company_ids = self._wizard_company_ids(self.parent_company + self.branch_a + self.branch_b)
+        self.assertIn(self.branch_b, company_ids, "La sucursal hermana debería estar disponible")
+        self.assertIn(self.parent_company, company_ids, "La casa matriz debería estar disponible")
+        self.assertNotIn(self.branch_a, company_ids, "La propia compañía actual no debe listarse")
+
+    def test_only_allowed_companies_are_listed(self):
+        """El listado debe respetar allowed_company_ids del usuario, aunque
+        haya más hermanas en la jerarquía (tarea #70688)."""
+        company_ids = self._wizard_company_ids(self.parent_company + self.branch_a)
+        self.assertNotIn(self.branch_b, company_ids, "No debería listar compañías fuera de allowed_company_ids")
+
+    def test_no_crash_without_move_context(self):
+        """Sin active_id en el contexto, move_id (y por lo tanto company_id)
+        queda vacío; el cómputo no debe romper con ensure_one()."""
+        wizard = self.env["account.change.company"].new({})
+        self.assertFalse(wizard.company_ids)
+
+    def test_grandchild_reaches_whole_tree(self):
+        """Parado en un nieto (3er nivel: Casa Matriz -> Sucursal Centro -> Centro AUX),
+        el wizard debe ofrecer toda la jerarquía accesible: la raíz, el padre directo
+        y las hermanas del padre — no solo el padre directo (ejemplo de Nico Col)."""
+        allowed = self.parent_company + self.branch_a + self.branch_b + self.branch_a_child
+        company_ids = self._wizard_company_ids(allowed, move=self.grandchild_move)
+        self.assertIn(self.parent_company, company_ids, "La raíz (abuela) debería estar disponible")
+        self.assertIn(self.branch_a, company_ids, "El padre directo debería estar disponible")
+        self.assertIn(self.branch_b, company_ids, "La hermana del padre (tía) debería estar disponible")
+        self.assertNotIn(self.branch_a_child, company_ids, "La propia compañía actual no debe listarse")

--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -37,15 +37,11 @@ class AccountChangeCompany(models.TransientModel):
     @api.depends("move_id")
     @api.depends_context("allowed_company_ids")
     def _compute_company_ids(self):
-        self.company_ids = self.env["res.company"].search(
-            [
-                "&",
-                ("id", "!=", self.move_id.company_id.id),
-                "|",
-                ("id", "parent_of", self.move_id.company_id.ids),
-                ("id", "child_of", self.move_id.company_id.ids),
-            ]
-        )
+        company = self.move_id.company_id
+        if not company:
+            self.company_ids = self.env["res.company"]
+            return
+        self.company_ids = company.root_id._accessible_branches() - company
 
     @api.depends("company_ids")
     def _compute_company(self):


### PR DESCRIPTION
## Summary

The "Change Company" wizard on invoices only offered the parent company as a switch target when the current document's company was a branch (child company) — sibling branches (other children of the same parent) never showed up, even when the user had permission for them. Users had to go through the parent company as an intermediate step to move between two sibling branches.

- `_compute_company_ids` now builds the list from the accessible branches of the top-most reference (the parent, or the company itself if it has none), reusing `res.company._accessible_branches()` (already used elsewhere in this module) instead of a hand-rolled `parent_of`/`child_of` domain.
- This also fixes a related gap: the previous domain did not filter by the user's `allowed_company_ids` at all.
- Added a guard for the case where the wizard is computed without a resolved `move_id` (no `active_id` in context), which previously would raise `ValueError` from `ensure_one()` on an empty recordset instead of degrading to an empty list, as the old `search()`-based implementation did.

## Test plan

- [x] New test: switching from a branch now offers both the parent company and sibling branches, not just the parent.
- [x] New test: the offered companies still respect `allowed_company_ids` (a sibling outside the allowed set is not listed).
- [x] New test: computing the wizard without a move context does not raise.
- [x] Full existing test suite of the module still passes (no regressions).