### PR TITLE
[IMP] stock_account_multicompany_ux: show stock of all branches

### DIFF
--- a/stock_account_multicompany_ux/README.rst
+++ b/stock_account_multicompany_ux/README.rst
@@ -14,11 +14,12 @@
 Stock Account Multicompany Usability
 ====================================
 
-Extends the stock-accounting integration for multi-company setups where a parent
-company has one or more branch companies. The key feature is **Shared Stock
-Valuation to Branches**: branches calculate COGS using the parent company's
-inventory cost instead of their own, ensuring a single unified cost across
-the entire group.
+Extends the stock integration for multi-company setups where a parent company has
+one or more branch companies. Two independent features: **Shared Stock Valuation
+to Branches**, where branches calculate COGS using the parent company's inventory
+cost instead of their own to keep a single unified cost across the group; and
+**Branch Stock**, which lets a user see where the group's stock is, without
+changing the quantity on hand of their own company.
 
 Features
 --------
@@ -46,6 +47,19 @@ Features
   difference between the branch cost and the parent cost to the appropriate
   inventory difference account when real-time valuation is active.
 
+- **Branch Stock** (``stock.location``, ``stock.quant`` record rules): new privilege
+  that lets a user read the locations and quants of the whole parent/branches scheme,
+  so the stock detail breakdowns list every warehouse of the group even for companies
+  the user cannot access. The **quantity on hand stays unchanged** — it keeps showing
+  only the user's own companies, because it is scoped by the active companies and not
+  by the record rules. The intent is that a salesperson sells from their own branch
+  first and only checks the rest of the group when their own stock is not enough.
+
+  Only **read** access is widened. Odoo's company rules on those two models keep
+  governing write, create and unlink with their original strict domain, so the user
+  cannot touch the other companies' records. Their read permission is turned off so
+  that the rules above are the ones that apply, and ``uninstall_hook`` restores it.
+
 Installation
 ============
 
@@ -54,6 +68,11 @@ To install this module, you need to:
 #. Install ``account_multicompany_ux`` and ``stock_account`` (declared as
    dependencies; they are installed automatically).
 #. Install this module.
+
+.. note::
+   The stock detail breakdowns themselves come from ``product_stock_by_location``
+   (product list and kanban) and ``sale_stock_ux`` (sale order line). They are not
+   dependencies: without them the privilege simply has nothing to widen.
 
 Configuration
 =============
@@ -69,6 +88,13 @@ Configuration
    The **Shared Stock Valuation to Branches** field is only visible when
    multi-company mode is active and the current company is *not* a branch
    (i.e. it has no parent company).
+
+To grant the **Branch Stock** privilege:
+
+#. Open **Settings → Users & Companies → Users** and edit the user.
+#. In the *Access Rights* tab, under **Supply Chain**, set **Branch Stock** to
+   *All Branches*. The default, *Own company only*, keeps Odoo's native
+   behaviour.
 
 Bug Tracker
 ===========

--- a/stock_account_multicompany_ux/__init__.py
+++ b/stock_account_multicompany_ux/__init__.py
@@ -1,1 +1,9 @@
 from . import models
+
+
+def uninstall_hook(env):
+    # Sin esto la lectura de stock quedaría sin ninguna regla de compañía.
+    for xml_id in ("stock.stock_location_comp_rule", "stock.stock_quant_rule"):
+        rule = env.ref(xml_id, raise_if_not_found=False)
+        if rule:
+            rule.perm_read = True

--- a/stock_account_multicompany_ux/__manifest__.py
+++ b/stock_account_multicompany_ux/__manifest__.py
@@ -19,7 +19,7 @@
 ##############################################################################
 {
     "name": "Stock Account Multicompany Usability",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.5.0",
     "author": "ADHOC SA",
     "website": "www.adhoc.com.ar",
     "license": "AGPL-3",
@@ -28,10 +28,12 @@
         "account_multicompany_ux",
     ],
     "data": [
+        "security/stock_account_multicompany_ux_security.xml",
         "views/product_category_views.xml",
         "views/product_views.xml",
     ],
     "demo": [],
+    "uninstall_hook": "uninstall_hook",
     "installable": True,
     "auto_install": True,
 }

--- a/stock_account_multicompany_ux/migrations/19.0.1.5.0/post-migration.py
+++ b/stock_account_multicompany_ux/migrations/19.0.1.5.0/post-migration.py
@@ -1,0 +1,17 @@
+def migrate(cr, version):
+    """
+    Saca la lectura de las reglas multicompañía de stock, que pasa a gobernar este
+    módulo. Están declaradas con noupdate="1", así que el XML solo las toca al
+    instalar: en una base ya instalada hay que forzarlo acá.
+    """
+    cr.execute(
+        """
+        UPDATE ir_rule SET perm_read = FALSE
+        WHERE id IN (
+            SELECT res_id FROM ir_model_data
+            WHERE model = 'ir.rule'
+              AND module = 'stock'
+              AND name IN ('stock_location_comp_rule', 'stock_quant_rule')
+        )
+        """
+    )

--- a/stock_account_multicompany_ux/models/__init__.py
+++ b/stock_account_multicompany_ux/models/__init__.py
@@ -5,3 +5,4 @@ from . import product_template
 from . import product_product
 from . import account_move
 from . import res_company
+from . import res_users

--- a/stock_account_multicompany_ux/models/res_users.py
+++ b/stock_account_multicompany_ux/models/res_users.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def _get_branch_stock_root_id(self):
+        # Se usa desde el dominio de las reglas de lectura de stock: False deja el
+        # dominio en falso, que es lo que corresponde cuando el permiso no aplica.
+        self.ensure_one()
+        if not self.has_group("stock_account_multicompany_ux.group_stock_all_branches"):
+            return False
+        return self.env.company.root_id.id

--- a/stock_account_multicompany_ux/security/stock_account_multicompany_ux_security.xml
+++ b/stock_account_multicompany_ux/security/stock_account_multicompany_ux_security.xml
@@ -1,0 +1,50 @@
+<odoo>
+
+    <!-- El grupo necesita privilegio: el formulario de usuario renderiza
+         categoría > privilegio > grupos y no lista los grupos sueltos. -->
+    <record model="res.groups.privilege" id="res_groups_privilege_branch_stock">
+        <field name="name">Branch Stock</field>
+        <field name="category_id" ref="base.module_category_supply_chain"/>
+        <field name="placeholder">Own company only</field>
+        <field name="sequence">50</field>
+        <field name="description">Determines whose stock the user sees in the stock detail breakdowns: only their own company, or the whole parent/branches scheme.</field>
+    </record>
+
+    <record model="res.groups" id="group_stock_all_branches">
+        <field name="name">All Branches</field>
+        <field name="privilege_id" ref="res_groups_privilege_branch_stock"/>
+        <field name="comment">Allows the user to see the stock detail of the whole parent/branches company scheme, even for companies they cannot access. The quantity on hand keeps showing the user's own companies; it is the location breakdown that lists every warehouse of the group. Read only: the user still cannot write on the other companies' records.</field>
+    </record>
+
+    <!-- Las reglas multicompañía de stock son globales y se combinan con AND, así que no
+         alcanza con sumar una permisiva: hay que sacarles la lectura y pasarla a estas.
+         Las de stock siguen gobernando write/create/unlink con su dominio estricto. -->
+    <record model="ir.rule" id="stock.stock_location_comp_rule">
+        <field name="perm_read" eval="False"/>
+    </record>
+
+    <record model="ir.rule" id="stock.stock_quant_rule">
+        <field name="perm_read" eval="False"/>
+    </record>
+
+    <record model="ir.rule" id="stock_location_read_rule">
+        <field name="name">Location multi-company: read (branch stock aware)</field>
+        <field name="model_id" ref="stock.model_stock_location"/>
+        <field name="domain_force">['|', ('company_id', 'in', company_ids + [False]), ('company_id', 'child_of', user._get_branch_stock_root_id())]</field>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+    <record model="ir.rule" id="stock_quant_read_rule">
+        <field name="name">stock_quant multi-company: read (branch stock aware)</field>
+        <field name="model_id" ref="stock.model_stock_quant"/>
+        <field name="domain_force">['|', ('company_id', 'in', company_ids + [False]), ('company_id', 'child_of', user._get_branch_stock_root_id())]</field>
+        <field name="perm_read" eval="True"/>
+        <field name="perm_write" eval="False"/>
+        <field name="perm_create" eval="False"/>
+        <field name="perm_unlink" eval="False"/>
+    </record>
+
+</odoo>


### PR DESCRIPTION
## What

Adds a **Branch Stock** privilege that expands the product quantities to every warehouse of the parent/branches company scheme, so a user assigned to a single branch can see the stock of the whole group. It applies to the product menu, the product catalog and the sale order lines.

## Why

In a parent + branches setup a user only sees the stock of the companies they are assigned to, with no way to know the group has stock elsewhere. Widening the scope needs two levers at once: the tree warehouses in the context **and** `sudo()` to get past the `stock.quant` / `stock.move` record rules. With only one of them the result is still the user's own company, because `env.companies` cannot be widened beyond the user's allowed companies.

## How

- `product.product._compute_quantities_dict()` is the single point every screen that displays stock goes through, so the expansion happens there.
- `sale_stock` pins the order's warehouse in `_read_qties()`, which cancels the expansion; that one is unpinned when the privilege is active. The product catalog needs no override: the sale order does not inject `warehouse_id` into its context.
- `_compute_quantities` is overridden on `product.product` and `product.template` only to add `uid` to the cache key. The quantity fields do not declare the user in their cache key, so two users of the same branch — same allowed companies — would otherwise share the cached value and the first read would win.
- The privilege hangs from its own `res.groups.privilege` because the user form renders category > privilege > groups and does not list standalone groups.

## Scope guards

- An explicit `warehouse_id` / `location` in the context wins over the privilege.
- Nothing is expanded when `env.su` is set, so internal flows (replenishment, valuation, reordering rules) keep the native single-company scope.
- No access is granted to the other companies' quants or moves: only the computed quantities are aggregated.

## Test plan

Parent company with two branches, one storable product shared across the tree, and stock 100 / 10 / 25 in the three warehouses. A user assigned only to the second branch (10 units), with and without the privilege:

| Check | Without | With |
|---|---|---|
| Product quantity on hand (variant and template) | 10 | 135 |
| Sale order line availability | 10 | 135 |
| Product catalog card | 10 | 135 |
| Filtering by the branch warehouse | 10 | 10 |
| Read in `sudo` | 10 | 10 |

Reading as both users within the same transaction returns the correct value in either order, covering the cache key.

## Note for reviewers

`sale_stock` becomes a dependency, so the module no longer auto-installs on databases without Sales. Databases that already have it installed are unaffected.
