### PR TITLE
[FIX] stock_account_multicompany_ux: value branch FIFO COGS with _run_fifo

### DIFF
--- a/stock_account_multicompany_ux/README.rst
+++ b/stock_account_multicompany_ux/README.rst
@@ -32,14 +32,16 @@ Features
   ``_get_cogs_price_unit()`` so that when a branch generates COGS entries for
   a category with shared valuation, the cost is taken from the parent company.
   Supports standard, average, and FIFO cost methods. For FIFO it looks up
-  equivalent parent-company stock moves; when none exist it falls back to the
-  parent's last stock valuation layer or standard price.
+  equivalent parent-company stock moves and weights their value by quantity;
+  when none exist it falls back to the parent's standard price.
 
 - **Branch-aware COGS value** (``account.move.line``): overrides
   ``_get_cogs_value()`` to apply the same parent-cost logic even when there are
   no associated stock moves (e.g. service products billed from a branch, or
-  credit notes). Also respects reversed-entry lines to avoid re-computing
-  already-posted COGS.
+  credit notes). With no stock moves, standard/average take the parent's
+  standard price and FIFO is valued with ``product._run_fifo()`` in the parent
+  company, same as standard Odoo. Also respects reversed-entry lines to avoid
+  re-computing already-posted COGS.
 
 - **Inventory difference lines** (``account.move``): overrides
   ``_stock_account_prepare_realtime_out_lines_vals()`` to post the price

--- a/stock_account_multicompany_ux/models/account_move_line.py
+++ b/stock_account_multicompany_ux/models/account_move_line.py
@@ -22,8 +22,8 @@ class AccountMoveLine(models.Model):
         2. stock.move._get_cogs_price_unit() si hay stock moves completados
            (ese método ya tiene su propio override para usar el costo del padre).
         3. Precio estándar del padre (si no hay stock moves, método standard/average).
-        4. Última capa SVL del padre como aproximación FIFO.
-        5. Precio estándar del padre como fallback final.
+        4. FIFO del padre vía product._run_fifo() (si no hay stock moves y el método
+           es FIFO), igual que Odoo estándar.
         """
         self.ensure_one()
 
@@ -76,23 +76,11 @@ class AccountMoveLine(models.Model):
                 # Standard/Average: usar el precio estándar vigente en el padre
                 price_unit = product_parent.standard_price
             else:
-                # FIFO: leer la última capa de valoración (SVL) del padre.
-                # No se consume ni ajusta ninguna capa; es solo una lectura del costo.
-                StockValuationLayer = self.env["stock.valuation.layer"]
-                svl = StockValuationLayer.search(
-                    [
-                        ("product_id", "=", product_parent.id),
-                        ("company_id", "=", parent_company.id),
-                    ],
-                    order="id desc",
-                    limit=1,
-                )
-                if svl:
-                    # Usar el costo unitario de la última capa como aproximación FIFO
-                    price_unit = svl.unit_cost
-                else:
-                    # Sin capas previas disponibles: caer al precio estándar del padre
-                    price_unit = product_parent.standard_price
+                # FIFO: valuar contra el stack FIFO del padre, igual que Odoo estándar
+                # (stock_account/models/account_move_line.py). _run_fifo() solo lee el
+                # valor de los stock.move del padre: no consume ni ajusta nada, y si no
+                # hay entradas previas extrapola con el precio estándar.
+                price_unit = product_parent._run_fifo(cogs_qty) / cogs_qty if cogs_qty else 0
 
         # Descontar el valor de COGS ya contabilizado en asientos anteriores
         # (ej. entregas parciales previamente facturadas) para evitar doble registro.

--- a/stock_account_multicompany_ux/tests/__init__.py
+++ b/stock_account_multicompany_ux/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_branch_shared_cogs

--- a/stock_account_multicompany_ux/tests/test_branch_shared_cogs.py
+++ b/stock_account_multicompany_ux/tests/test_branch_shared_cogs.py
@@ -1,0 +1,256 @@
+from odoo import Command
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestBranchSharedCogs(TransactionCase):
+    """COGS de una branch para categorías con valoración compartida.
+
+    Los datos se crean a mano (sin plan de cuentas ni demo data) para que el test
+    corra igual en una base mínima y en una base OBA completa.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.parent_company = cls.env["res.company"].create({"name": "Parent Co 71584"})
+        cls.branch_company = cls.env["res.company"].create(
+            {"name": "Branch Co 71584", "parent_id": cls.parent_company.id}
+        )
+        cls.env.user.company_ids = [Command.link(cls.parent_company.id), Command.link(cls.branch_company.id)]
+        # La branch va primera: la propagación de shared_to_branches solo alcanza
+        # a las branches accesibles en el contexto.
+        cls.env = cls.env(
+            context=dict(cls.env.context, allowed_company_ids=[cls.branch_company.id, cls.parent_company.id])
+        )
+
+        cls.account_receivable = cls._create_account(cls, "AR71584", "Receivable", "asset_receivable")
+        cls.account_income = cls._create_account(cls, "IN71584", "Income", "income")
+        cls.account_expense = cls._create_account(cls, "EX71584", "Expense", "expense")
+        cls.account_stock_valuation = cls._create_account(cls, "SV71584", "Stock Valuation", "asset_current")
+
+        cls.journal_sale = (
+            cls.env["account.journal"]
+            .with_company(cls.parent_company)
+            .create(
+                {
+                    "name": "Sales 71584",
+                    "code": "SA716",
+                    "type": "sale",
+                    "company_id": cls.parent_company.id,
+                    "default_account_id": cls.account_income.id,
+                }
+            )
+        )
+        cls.journal_stock = (
+            cls.env["account.journal"]
+            .with_company(cls.parent_company)
+            .create(
+                {
+                    "name": "Stock 71584",
+                    "code": "ST716",
+                    "type": "general",
+                    "company_id": cls.parent_company.id,
+                }
+            )
+        )
+
+        cls.categ = (
+            cls.env["product.category"]
+            .with_company(cls.parent_company)
+            .create(
+                {
+                    "name": "Shared FIFO 71584",
+                    "property_cost_method": "fifo",
+                    "property_valuation": "real_time",
+                    "shared_to_branches": True,
+                    "property_account_income_categ_id": cls.account_income.id,
+                    "property_account_expense_categ_id": cls.account_expense.id,
+                    "property_stock_valuation_account_id": cls.account_stock_valuation.id,
+                    "property_stock_journal": cls.journal_stock.id,
+                }
+            )
+        )
+
+        cls.product = (
+            cls.env["product.product"]
+            .with_company(cls.parent_company)
+            .create(
+                {
+                    "name": "Product 71584",
+                    "is_storable": True,
+                    "categ_id": cls.categ.id,
+                    "standard_price": 100.0,
+                }
+            )
+        )
+
+        # Entrada valorizada en el padre: 10 unidades a 100 => el stack FIFO del
+        # padre vale 100 por unidad.
+        warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.parent_company.id)], limit=1)
+        move = (
+            cls.env["stock.move"]
+            .with_company(cls.parent_company)
+            .create(
+                {
+                    "product_id": cls.product.id,
+                    "product_uom_qty": 10.0,
+                    "location_id": cls.env.ref("stock.stock_location_suppliers").id,
+                    "location_dest_id": warehouse.lot_stock_id.id,
+                    "company_id": cls.parent_company.id,
+                }
+            )
+        )
+        move._action_confirm()
+        move.quantity = 10.0
+        move.picked = True
+        move._action_done()
+        cls.parent_in_move = move
+
+        # Precio estándar distinto del costo real de la entrada: si el COGS sale 500
+        # es porque cayó al standard price en vez de valuar contra el FIFO del padre.
+        cls.product.with_company(cls.parent_company).standard_price = 500.0
+
+        cls.partner = cls.env["res.partner"].create({"name": "Customer 71584"})
+        for company in (cls.parent_company, cls.branch_company):
+            cls.partner.with_company(company).property_account_receivable_id = cls.account_receivable
+
+    def _create_account(self, code, name, account_type):
+        return (
+            self.env["account.account"]
+            .with_company(self.parent_company)
+            .create(
+                {
+                    "code": code,
+                    "name": name,
+                    "account_type": account_type,
+                    "company_ids": [Command.link(self.parent_company.id)],
+                }
+            )
+        )
+
+    def _create_branch_invoice(self, quantity=3.0):
+        """Factura de la branch sin movimientos de stock asociados."""
+        return (
+            self.env["account.move"]
+            .with_company(self.branch_company)
+            .create(
+                {
+                    "move_type": "out_invoice",
+                    "company_id": self.branch_company.id,
+                    "partner_id": self.partner.id,
+                    "journal_id": self.journal_sale.id,
+                    "invoice_date": "2026-01-15",
+                    "invoice_date_due": "2026-01-15",
+                    "invoice_line_ids": [
+                        Command.create(
+                            {
+                                "product_id": self.product.id,
+                                "quantity": quantity,
+                                "price_unit": 150.0,
+                                "tax_ids": [Command.clear()],
+                            }
+                        )
+                    ],
+                }
+            )
+        )
+
+    def test_setup_is_the_fifo_without_moves_scenario(self):
+        """El escenario es el que dispara la rama FIFO sin movimientos de stock."""
+        invoice = self._create_branch_invoice()
+        line = invoice.invoice_line_ids
+
+        self.assertEqual(invoice.company_id, self.branch_company)
+        self.assertTrue(invoice.company_id.parent_id)
+        self.assertTrue(self.categ.with_company(self.parent_company).shared_to_branches)
+        self.assertEqual(self.product.with_company(self.parent_company).cost_method, "fifo")
+        self.assertEqual(self.product.with_company(self.branch_company).valuation, "real_time")
+        self.assertFalse(line._get_stock_moves().filtered(lambda m: m.state == "done"))
+
+    def test_cogs_value_uses_parent_fifo_stack(self):
+        """Sin stock moves y con FIFO, el COGS se valúa contra el FIFO del padre.
+
+        Antes del fix este camino leía `stock.valuation.layer`, modelo eliminado en
+        Odoo 19, y levantaba KeyError.
+        """
+        invoice = self._create_branch_invoice()
+
+        self.assertEqual(invoice.invoice_line_ids._get_cogs_value(), 100.0)
+
+    def test_post_generates_balanced_cogs_at_parent_cost(self):
+        """Confirmar la factura genera el par de COGS al costo del padre."""
+        invoice = self._create_branch_invoice()
+
+        invoice.action_post()
+
+        cogs_lines = invoice.line_ids.filtered(lambda line: line.display_type == "cogs")
+        self.assertEqual(len(cogs_lines), 2)
+        self.assertEqual(sum(cogs_lines.mapped("debit")), 300.0)
+        self.assertEqual(sum(cogs_lines.mapped("credit")), 300.0)
+        self.assertEqual(
+            cogs_lines.filtered(lambda line: line.debit).account_id,
+            self.account_expense,
+        )
+        self.assertEqual(
+            cogs_lines.filtered(lambda line: line.credit).account_id,
+            self.account_stock_valuation,
+        )
+
+    def test_cogs_value_falls_back_to_standard_price_without_parent_stock(self):
+        """Sin entradas en el padre, FIFO extrapola con el precio estándar del padre."""
+        product = (
+            self.env["product.product"]
+            .with_company(self.parent_company)
+            .create(
+                {
+                    "name": "Product 71584 sin stock",
+                    "is_storable": True,
+                    "categ_id": self.categ.id,
+                    "standard_price": 250.0,
+                }
+            )
+        )
+        invoice = self._create_branch_invoice()
+        invoice.invoice_line_ids.product_id = product
+
+        self.assertEqual(invoice.invoice_line_ids._get_cogs_value(), 250.0)
+
+    def test_cogs_value_untouched_when_category_not_shared(self):
+        """Categoría sin shared_to_branches: el override no interviene."""
+        categ = (
+            self.env["product.category"]
+            .with_company(self.parent_company)
+            .create(
+                {
+                    "name": "Not shared 71584",
+                    "property_cost_method": "standard",
+                    "property_valuation": "real_time",
+                    "property_account_income_categ_id": self.account_income.id,
+                    "property_account_expense_categ_id": self.account_expense.id,
+                    "property_stock_valuation_account_id": self.account_stock_valuation.id,
+                    "property_stock_journal": self.journal_stock.id,
+                }
+            )
+        )
+        product = (
+            self.env["product.product"]
+            .with_company(self.parent_company)
+            .create(
+                {
+                    "name": "Product 71584 no compartido",
+                    "is_storable": True,
+                    "categ_id": categ.id,
+                    "standard_price": 900.0,
+                }
+            )
+        )
+        # Cada compañía con su propio costo: sin categoría compartida el COGS de la
+        # branch se valúa con el costo de la branch, no con el del padre.
+        product.with_company(self.branch_company).standard_price = 70.0
+        invoice = self._create_branch_invoice()
+        invoice.invoice_line_ids.product_id = product
+
+        self.assertFalse(categ.with_company(self.parent_company).shared_to_branches)
+        self.assertEqual(invoice.invoice_line_ids._get_cogs_value(), 70.0)


### PR DESCRIPTION
## What was failing

`stock_account_multicompany_ux` overrides `account.move.line._get_cogs_value()` to value a branch's COGS at the parent company cost. In the FIFO path with no stock moves it read `self.env["stock.valuation.layer"]`, a model **removed in Odoo 19**, so it raised `KeyError: 'stock.valuation.layer'`.

It is not a theoretical path: confirming a customer invoice hits it. Reproduced on a v19 database with the module installed:

```
account/models/account_move.py action_post
  -> stock_account/models/account_move.py _post
    -> stock_account_multicompany_ux/models/account_move.py _stock_account_prepare_realtime_out_lines_vals
      -> stock_account/models/account_move.py:122
        -> stock_account_multicompany_ux/models/account_move_line.py:81 _get_cogs_value
KeyError: 'stock.valuation.layer'
```

Conditions to reach it: invoice issued by a company with a parent, product category with `shared_to_branches` + FIFO costing + perpetual valuation (and its stock valuation / expense accounts set), storable product, and an invoice line with no stock moves in state `done` (manual invoice, no delivery). Anglo-saxon accounting is not required.

## The fix

Value that branch with `product._run_fifo()` in the parent company, exactly what standard Odoo does in v19 (`stock_account/models/account_move_line.py`):

```python
price_unit = product_parent._run_fifo(cogs_qty) / cogs_qty if cogs_qty else 0
```

`_run_fifo()` reads the FIFO stack from `stock.move.value` without consuming or adjusting anything — same read-only semantics the previous code intended — and extrapolates with the standard price when the parent has no previous incoming moves.

`README.rst` also described the old layer lookup (for both overrides) and was corrected.

## Tests

First tests for this module (`tests/test_branch_shared_cogs.py`, `TransactionCase` with hand-built data, no demo data). Coverage:

- FIFO with no stock moves: COGS is valued against the parent FIFO stack. Parent receives 10 units at cost 100 and its standard price is then set to 500, so the assertion (100) discriminates between reading the new valuation source and falling back to the standard price.
- Posting generates the balanced COGS pair at the parent cost (300 debit / 300 credit against the expected accounts).
- FIFO with no incoming moves in the parent: extrapolates with the parent standard price.
- Non-shared category: the override does not intervene and the branch cost is used.
- Guard test asserting the scenario really is "branch + shared category + FIFO + no done stock moves".

Verification: 5/5 pass with the fix; reverting only the fixed file makes 3 of them error with `KeyError: 'stock.valuation.layer'`, so they do cover the bug.

Task: https://www.adhoc.inc/odoo/project.task/71584