### PR TITLE
[ADD] account_branch_fiscalyear: allow a different fiscal year on branches

### DIFF
--- a/account_branch_fiscalyear/README.rst
+++ b/account_branch_fiscalyear/README.rst
@@ -1,0 +1,112 @@
+.. |company| replace:: ADHOC SA
+
+.. |company_logo| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-logo.png
+   :alt: ADHOC SA
+   :target: https://www.adhoc.com.ar
+
+.. |icon| image:: https://raw.githubusercontent.com/ingadhoc/maintainer-tools/master/resources/adhoc-icon.png
+
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+==========================
+Account Branch Fiscal Year
+==========================
+
+Permite que las sucursales (*branches*) de un mismo árbol de compañías tengan
+un cierre de ejercicio distinto al de la compañía raíz.
+
+Por default Odoo delega cinco campos de la compañía raíz a sus sucursales
+(``currency_id``, ``fiscalyear_last_day``, ``fiscalyear_last_month``,
+``account_storno`` y ``tax_exigibility``), y los hace cumplir con cuatro
+mecanismos: el campo readonly en la vista, la copia en ``create``, la
+propagación a las hijas en ``write`` y un constraint de Python. Este módulo
+saca **solo los dos campos del ejercicio** de esa lista. El resto de la
+delegación —la moneda entre ellos— queda intacta.
+
+Qué hace exactamente
+====================
+
+#. El cierre de ejercicio queda **editable** en la ficha de la sucursal.
+#. Un cambio de ejercicio en la raíz **ya no pisa** el de sus sucursales.
+#. Una sucursal nueva **sigue naciendo con el ejercicio de su raíz**: la
+   divergencia es la excepción, no el default. Se restituye la copia en
+   ``create`` y en el ``onchange`` de la compañía padre.
+#. Lo que resuelve el ejercicio con la compañía del registro pasa a verlo
+   bien: amortizaciones, la secuencia por ejercicio de los asientos, el libro
+   diario y la valuación continental de stock.
+
+Limitaciones — leer antes de instalarlo
+=======================================
+
+**Este módulo levanta la restricción; no arregla todo lo que la restricción
+tapaba.** Hay tres lugares donde el ejercicio no se resuelve con la compañía
+de la sucursal, y siguen igual con el módulo instalado:
+
+#. **Fechas de bloqueo.** Se resuelven recorriendo la cadena de compañías
+   padre y tomando el máximo. Cuando la raíz cierra su ejercicio y pone la
+   fecha de bloqueo, **bloquea también a las sucursales**, en medio del
+   ejercicio de la sucursal. Los bloqueos blandos admiten excepción por
+   usuario (``account.lock_exception``); el bloqueo duro (*hard lock date*)
+   no admite ninguna, por diseño.
+#. **Corte del resultado del ejercicio en los reportes.** El libro mayor y
+   sumas y saldos calculan el inicio del ejercicio **una sola vez, con la
+   compañía activa**, y lo aplican a las líneas de todas las compañías
+   seleccionadas. Con cierres dispares, el saldo inicial y el resultado de la
+   sucursal quedan cortados por el ejercicio de la raíz. No da error: da un
+   número distinto del correcto.
+#. **Declaraciones (``account.return``).** Se generan por compañía raíz (o por
+   la compañía principal de la unidad fiscal). Una sucursal con ejercicio
+   propio no tiene período anual propio: sus declaraciones anuales las arma la
+   raíz con el ejercicio de la raíz.
+
+Además, el módulo **no habilita ejercicios explícitos por sucursal**: el
+modelo ``account.fiscal.year`` tiene su propio constraint que los prohíbe en
+una compañía hija. Si el cliente necesita ejercicios irregulares (de
+transición, de más de doce meses), eso queda afuera.
+
+Por eso el módulo **no es auto-instalable y no es parte del set estándar**:
+la instalación es la decisión de aceptar esas tres limitaciones para una base
+concreta. El análisis completo, con la evidencia en código y las dos
+alternativas de implementación evaluadas, está en la tarea **#71643**.
+
+Installation
+============
+
+To install this module, you need to:
+
+#. Only install the module
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+#. Nada que configurar. Después de instalarlo, el cierre de ejercicio de cada
+   sucursal se edita en su propia ficha de compañía.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: http://runbot.adhoc.com.ar/
+
+**Al instalarlo sobre una base existente hay que corregir los datos.** El
+``create`` de Odoo ya copió el ejercicio de la raíz a cada sucursal cuando se
+crearon: levantar la restricción no restaura nada. Hay que escribir el
+ejercicio correcto en cada sucursal que corresponda.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/ingadhoc/multi-company/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+* |company| |icon|

--- a/account_branch_fiscalyear/__init__.py
+++ b/account_branch_fiscalyear/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import models

--- a/account_branch_fiscalyear/__manifest__.py
+++ b/account_branch_fiscalyear/__manifest__.py
@@ -1,0 +1,34 @@
+##############################################################################
+#
+#    Copyright (C) 2026  ADHOC SA  (http://www.adhoc.com.ar)
+#    All Rights Reserved.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Account Branch Fiscal Year",
+    "version": "19.0.1.0.0",
+    "author": "ADHOC SA",
+    "website": "www.adhoc.com.ar",
+    "license": "AGPL-3",
+    "category": "Accounting",
+    "depends": [
+        "account",
+    ],
+    "data": [],
+    "demo": [],
+    "installable": True,
+    "auto_install": False,
+}

--- a/account_branch_fiscalyear/models/__init__.py
+++ b/account_branch_fiscalyear/models/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import res_company

--- a/account_branch_fiscalyear/models/res_company.py
+++ b/account_branch_fiscalyear/models/res_company.py
@@ -1,0 +1,62 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from odoo import api, models
+
+# Los dos campos de contabilidad que dejan de delegarse a la compañía raíz.
+# El resto de los campos delegados (currency_id, account_storno,
+# tax_exigibility) se siguen delegando: acá solo tocamos el ejercicio.
+FISCALYEAR_FIELD_NAMES = ("fiscalyear_last_day", "fiscalyear_last_month")
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    def _get_company_root_delegated_field_names(self):
+        """Saca el ejercicio fiscal de la delegación a la compañía raíz.
+
+        Core delega cinco campos a la raíz y los hace cumplir con cuatro
+        mecanismos, los cuatro apoyados en este método: el campo readonly en la
+        vista (`_get_view`), la copia en `create`, la propagación a las hijas en
+        `write` y el constraint `_check_root_delegated_fields`. Sacar los dos
+        campos del ejercicio de la lista levanta los cuatro de una.
+
+        De los cuatro, el único que no queremos perder es la copia en `create`:
+        una sucursal nueva tiene que seguir naciendo con el ejercicio de su
+        raíz, porque la divergencia es la excepción y no el default. Eso se
+        restituye más abajo (`create` y `_onchange_parent_id`).
+        """
+        return [
+            fname for fname in super()._get_company_root_delegated_field_names() if fname not in FISCALYEAR_FIELD_NAMES
+        ]
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Restituye la herencia del ejercicio en la creación de una sucursal.
+
+        Solo como valor inicial: después queda editable y no se vuelve a
+        propagar (a diferencia de un campo delegado, donde un cambio en la raíz
+        pisa a todas las hijas).
+        """
+        for vals in vals_list:
+            if parent := self.browse(vals.get("parent_id")):
+                for fname in FISCALYEAR_FIELD_NAMES:
+                    vals.setdefault(fname, self._fields[fname].convert_to_write(parent[fname], parent))
+        return super().create(vals_list)
+
+    @api.onchange("parent_id")
+    def _onchange_parent_id_fiscalyear(self):
+        """Idem `create`, pero para el form: al elegir la raíz, el ejercicio se
+        propone desde ella. Core lo hacía en `_onchange_parent_id` recorriendo
+        los campos delegados, y el ejercicio ya no está en esa lista.
+
+        Hace falta además de `create` porque el cliente web manda todos los
+        campos del registro nuevo, así que el `setdefault` de `create` no llega
+        a aplicar cuando la sucursal se crea desde la interfaz.
+        """
+        if self.parent_id:
+            for fname in FISCALYEAR_FIELD_NAMES:
+                if self[fname] != self.parent_id[fname]:
+                    self[fname] = self.parent_id[fname]

--- a/account_branch_fiscalyear/tests/__init__.py
+++ b/account_branch_fiscalyear/tests/__init__.py
@@ -1,0 +1,5 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from . import test_branch_fiscalyear

--- a/account_branch_fiscalyear/tests/test_branch_fiscalyear.py
+++ b/account_branch_fiscalyear/tests/test_branch_fiscalyear.py
@@ -1,0 +1,77 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+
+from datetime import date
+
+from odoo.exceptions import ValidationError
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestBranchFiscalYear(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company = cls.env["res.company"].create(
+            {
+                "name": "Test Root 71643",
+                "fiscalyear_last_day": 31,
+                "fiscalyear_last_month": "7",
+            }
+        )
+        cls.branch = cls.env["res.company"].create(
+            {
+                "name": "Test Branch 71643",
+                "parent_id": cls.company.id,
+            }
+        )
+
+    def test_01_branch_inherits_fiscalyear_on_create(self):
+        """La sucursal nueva nace con el ejercicio de su raíz."""
+        self.assertEqual(self.branch.fiscalyear_last_day, 31)
+        self.assertEqual(self.branch.fiscalyear_last_month, "7")
+
+    def test_02_branch_can_diverge(self):
+        """La sucursal puede tener un cierre distinto al de la raíz."""
+        self.branch.write(
+            {
+                "fiscalyear_last_day": 31,
+                "fiscalyear_last_month": "12",
+            }
+        )
+        self.assertEqual(self.branch.fiscalyear_last_month, "12")
+        self.assertEqual(self.company.fiscalyear_last_month, "7")
+
+    def test_03_root_write_does_not_propagate(self):
+        """Un cambio en la raíz no pisa el ejercicio propio de la sucursal.
+
+        Es la diferencia central con un campo delegado: ahí el `write` de la
+        raíz sobreescribe a todas las hijas.
+        """
+        self.branch.fiscalyear_last_month = "12"
+        self.company.fiscalyear_last_month = "4"
+        self.assertEqual(self.branch.fiscalyear_last_month, "12")
+
+    def test_04_fiscalyear_dates_follow_the_branch(self):
+        """`compute_fiscalyear_dates` de la sucursal usa su propio ejercicio.
+
+        Es el objetivo funcional del módulo: lo que consuma el ejercicio con la
+        compañía de la sucursal (amortizaciones, secuencias, libro diario)
+        pasa a verlo bien.
+        """
+        self.branch.write({"fiscalyear_last_day": 31, "fiscalyear_last_month": "12"})
+        reference = date(2026, 3, 15)
+
+        root_dates = self.company.compute_fiscalyear_dates(reference)
+        branch_dates = self.branch.compute_fiscalyear_dates(reference)
+
+        self.assertEqual(root_dates["date_to"], date(2026, 7, 31))
+        self.assertEqual(branch_dates["date_to"], date(2026, 12, 31))
+
+    def test_05_currency_is_still_delegated(self):
+        """No tocamos el resto de la delegación: la moneda sigue atada a la raíz."""
+        other_currency = self.env["res.currency"].search([("id", "!=", self.company.currency_id.id)], limit=1)
+        with self.assertRaises(ValidationError):
+            self.branch.currency_id = other_currency


### PR DESCRIPTION
Nuevo módulo, no auto-instalable, que permite que las sucursales (*branches*) de un mismo árbol de compañías tengan un cierre de ejercicio distinto al de la compañía raíz.

## Qué hace

Odoo delega cinco campos de la raíz a sus sucursales (`currency_id`, `fiscalyear_last_day`, `fiscalyear_last_month`, `account_storno`, `tax_exigibility`) y lo hace cumplir con cuatro mecanismos, los cuatro apoyados en `_get_company_root_delegated_field_names()`: campo readonly en la vista (`_get_view`), copia en `create`, propagación a las hijas en `write` y el constraint `_check_root_delegated_fields`. El módulo saca **solo los dos campos del ejercicio** de esa lista, así que los cuatro mecanismos se levantan para ellos. El resto de la delegación, la moneda incluida, queda intacta (hay un test que lo verifica).

De los cuatro mecanismos hay uno que no queremos perder: **la copia en `create`**. Se restituye a propósito, en `create` y en un onchange de `parent_id`, porque si no, una sucursal creada bajo una raíz que cierra el 30/04 nacería en 31/12 sin que nadie se dé cuenta. La divergencia queda como excepción explícita y no como default. El onchange hace falta además de `create` porque el cliente web manda todos los campos del registro nuevo y el `setdefault` de `create` no llega a aplicar.

## Por qué no es auto-instalable

Levantar la restricción no arregla los tres lugares donde el ejercicio no se resuelve con la compañía de la sucursal, y por eso instalarlo **es** la decisión de aceptar esas limitaciones. Están escritas en el README:

1. **Fechas de bloqueo** — se resuelven recorriendo la cadena de padres y tomando el máximo (`_get_user_lock_date`, y el hard lock igual), así que cerrar el ejercicio en la raíz bloquea también a las sucursales. El hard lock no admite excepción por diseño.
2. **Corte del resultado en los reportes** — el libro mayor y sumas y saldos calculan el inicio del ejercicio una sola vez con la compañía activa y lo aplican a las líneas de todas las compañías seleccionadas. No da error: da un número distinto del correcto.
3. **Declaraciones (`account.return`)** — se generan por compañía raíz, así que una sucursal con ejercicio propio no tiene período anual propio.

Tampoco habilita ejercicios explícitos por sucursal: `account.fiscal.year` tiene su propio constraint que los prohíbe en una compañía hija, y queda fuera de este módulo.

## Test plan

- `--test-tags /account_branch_fiscalyear` — 5 tests: la sucursal nace con el ejercicio de la raíz, puede divergir, un `write` en la raíz no la pisa, `compute_fiscalyear_dates` de la sucursal usa su propio ejercicio, y la moneda sigue delegada (sigue levantando `ValidationError`).
- Al instalarlo sobre una base existente hay que corregir datos: el `create` de Odoo ya copió el ejercicio de la raíz a cada sucursal cuando se crearon, así que levantar la restricción no restaura nada.

El análisis de impacto que motivó el módulo, con la evidencia en código y la alternativa de implementación evaluada, está en https://www.adhoc.inc/odoo/project.task/71643