### PR TITLE
[FIX] account_multicompany_ux: don't recompute taxes on deleted dynamic lines

### DIFF
--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -109,18 +109,23 @@ class AccountChangeCurrency(models.TransientModel):
         if invoice_payment_term_id:
             self.move_id.invoice_payment_term_id = invoice_payment_term_id
         without_product = self.move_id.line_ids.filtered(lambda line : line.display_type == 'product' and not line.product_id)
-        (self.move_id.line_ids - without_product).with_company(self.company_id.id)._compute_account_id()
+        (self.move_id.line_ids - without_product).exists().with_company(self.company_id.id)._compute_account_id()
         for line in without_product:
             line.account_id = line.move_id.journal_id.default_account_id
         if original_payment_term:
             self.move_id.invoice_payment_term_id = original_payment_term.id
 
-        # Recompute taxes for product lines (excluding discount lines)
-        (self.move_id.line_ids - original_discount_lines).with_company(self.company_id.id)._compute_tax_ids()
+        # Recompute taxes for product lines (excluding discount lines).
+        # Solo las líneas de factura: las dinámicas (tax, epd, payment_term) las regenera
+        # el sync de Odoo al reponer el payment term, y a esta altura pueden estar borradas.
+        # Escribirles tax_ids sobre un recordset viejo rompe con "Registro faltante".
+        self.move_id.flush_recordset()
+        (self.move_id.invoice_line_ids - original_discount_lines).exists().with_company(
+            self.company_id.id)._compute_tax_ids()
 
         # Recompute taxes for discount lines
         if original_discount_lines:
-            self._get_change_company_discount_tax(original_discount_lines, original_discount_taxes)
+            self._get_change_company_discount_tax(original_discount_lines.exists(), original_discount_taxes)
 
         self.move_id._compute_partner_bank_id()
         # PARTNER BANK


### PR DESCRIPTION
### Problema

En una factura cuya condición de pago tiene descuento por pago anticipado con la reducción de impuesto computada siempre en la factura (`early_pay_discount_computation = 'mixed'`), el asistente de cambio de compañía falla con:

```
Record does not exist or has been deleted. (Record: account.move.line(N,))
```

El registro reportado cambia en cada intento, por eso no se encuentra desde la UI: es una línea que el propio wizard elimina y que la transacción restituye al hacer rollback.

### Causa

La factura lleva líneas dinámicas `epd` y sus líneas de impuesto. Al reponer el payment term al final de `change_company()`, el sync de `account.move` las elimina y las vuelve a crear. El recordset leído de `move.line_ids` puede seguir teniendo esos ids, y `_compute_tax_ids()` termina escribiendo `tax_ids` sobre una línea ya borrada.

El core saltea las líneas `payment_term` en `_compute_tax_ids()` pero no las `epd` ni las `tax`, así que con una condición de pago común el problema no se manifiesta.

### Solución

- Recomputar impuestos solo sobre `invoice_line_ids`, como ya quedó en 18.0 tras el refactor de `[REF] _multicompany_ux: re-compute all lines`. Las líneas dinámicas las regenera el sync. No se pierde alcance: las líneas de anticipo y de descuento son líneas de producto.
- `flush_recordset()` antes de leer las líneas, para que el borrado/recreación ocurra antes y no en medio del write siguiente.
- `exists()` en los recordsets armados al inicio del método, que sobreviven a varios borrados intermedios.

18.0 y 19.0 no están afectadas.