### PR TITLE
[FIX] account_multicompany_ux: recompute taxes when changing the company of a customer invoice

### DIFF
--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -74,6 +74,7 @@ class AccountChangeCompany(models.TransientModel):
     def change_company(self):
         self.ensure_one()
         old_payment_term = self.move_id.invoice_payment_term_id
+        old_fiscal_position = self.move_id.fiscal_position_id
         vals = {
             "company_id": self.company_id.id,
             "journal_id": self.journal_id.id,
@@ -82,3 +83,12 @@ class AccountChangeCompany(models.TransientModel):
             vals["invoice_payment_term_id"] = old_payment_term.id
         self.move_id.with_context(skip_invoice_sync=True).write(vals)
         self.move_id.line_ids._compute_account_id() if self.move_id.line_ids else None
+        if (
+            self.move_id.state == "draft"
+            and self.move_id.is_sale_document(include_receipts=True)
+            and self.move_id.fiscal_position_id != old_fiscal_position
+        ):
+            # the write recomputes the fiscal position but not tax_ids, so we call the same method as the
+            # "Update Taxes" button. Only if the fiscal position changed: it recomputes taxes from the
+            # product, discarding the ones set by hand.
+            self.move_id.action_update_fpos_values()


### PR DESCRIPTION
## Problema

El wizard "Cambiar compañía" (`account.change.company`) escribe `company_id` / `journal_id` por código, así que no hay onchange sobre el move. La posición fiscal se recomputa (depende de `company_id`), pero los impuestos de las líneas no (`tax_ids` depende de `product_id` / `product_uom_id`) — de ahí el botón "Update Taxes" de Odoo.

Resultado: la factura queda con los impuestos de la compañía anterior hasta que el usuario aprieta el botón a mano. En Argentina, con una posición fiscal de percepciones en la compañía destino, las percepciones no aparecen ni en las líneas ni en el total.

## Solución

Para **facturas de cliente en borrador** cuya posición fiscal realmente cambió, después de escribir compañía + diario llamamos a `action_update_fpos_values()` — el mismo método del botón "Update Taxes" —, que recomputa dentro del sync de líneas dinámicas, así se rearman las líneas de impuesto y los totales.

Detalles:

- Primero `_compute_account_id()` y después los impuestos: al revés, con la línea apuntando a una cuenta de la compañía anterior, la creación de la línea de impuesto falla por check_company.
- Solo si la posición fiscal cambió: el método recomputa `tax_ids` desde el producto y descarta los impuestos seteados a mano.
- Facturas de proveedor y asientos conservan el comportamiento actual.

## Limitación conocida

Es la misma que tiene el botón "Actualizar impuestos" del core: `action_update_fpos_values()` no setea `tax_ids` a mano sino que reencola el compute, y `_compute_tax_ids` tiene el guard *"don't remove existing taxes if there is no explicit taxes set on the account"*. Entonces una línea **sin producto**, con una **cuenta sin impuestos por defecto** y con impuestos ya cargados, se saltea: conserva los de la compañía anterior y hay que ajustarla a mano.

En la práctica el fix cubre las líneas con producto (el caso del ticket); las líneas tipeadas a mano quedan a revisar por el usuario.

Sin migration script → `nobump`.

Ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/121872
