### PR TITLE
[FIX] account_multicompany_ux: set document number before posting vendor bill

### DIFF
--- a/account_multicompany_ux/tests/test_account_multicompany_ux_unit_test.py
+++ b/account_multicompany_ux/tests/test_account_multicompany_ux_unit_test.py
@@ -84,6 +84,36 @@ class TestAccountMulticompanyUxUnitTest(TransactionCase):
             }
         )
 
+    def _fill_latam_document_number(self, invoice):
+        """Completa el número de documento cuando el diario exige cargarlo a mano.
+
+        En una localización LATAM el número de una factura de proveedor es el del
+        comprobante que emitió el proveedor, así que se tipea a mano y no sale de
+        nuestra secuencia: ``_is_manual_document_number`` devuelve True para todo
+        diario de compras con documentos, y sin número ``_check_l10n_latam_documents``
+        rechaza el asiento al postearlo.
+
+        Este test no arma su propia compañía ni su propio diario: ``setUp`` toma los
+        primeros que encuentra en la base, así que le puede tocar un diario con
+        documentos o uno sin ellos según qué localizaciones tenga instaladas el build.
+        De ahí que el número se complete solo cuando hace falta.
+
+        El formato depende del país y no hay un literal que sirva para todos: AR parte
+        el número por el guion y rechaza lo que no tenga las dos partes
+        (``l10n_ar``, ``_format_document_number``), mientras que CL exige solo dígitos
+        (``l10n_cl``, ``_check_l10n_latam_document_number_is_numeric``).
+        """
+        if "l10n_latam_manual_document_number" not in invoice._fields:
+            # l10n_latam_invoice_document no es dependencia de este módulo.
+            return
+        if not invoice.l10n_latam_manual_document_number or invoice.l10n_latam_document_number:
+            return
+        if invoice.company_id.country_id.code == "AR":
+            # l10n_ar lo normaliza a 00001-00000001.
+            invoice.l10n_latam_document_number = "1-1"
+        else:
+            invoice.l10n_latam_document_number = "1"
+
     def test_multicompany_sale_order(self):
         """Cambio de compañía de una factura que cuenta con res partner bank seteado para la compañia original"""
         invoice = self.env["account.move"].create(
@@ -207,6 +237,7 @@ class TestAccountMulticompanyUxUnitTest(TransactionCase):
         self.assertTrue(self.account_payable.id in vendor_bill.line_ids.mapped("account_id.id"))
 
         customer_invoice.action_post()
+        self._fill_latam_document_number(vendor_bill)
         vendor_bill.action_post()
 
     def test_change_company_keeps_ar_perception_move_line(self):


### PR DESCRIPTION
## Problema

`TestAccountMulticompanyUxUnitTest.test_account_receivable` falla de forma intermitente en la integración continua:

```
odoo.exceptions.ValidationError: Please set the document number on the following invoices [116].
```

El test postea una factura de proveedor sin número de documento. Si el diario que le tocó usa documentos, `_is_manual_document_number()` devuelve `True` —lo hace para todo diario de compras, porque el número de una factura de proveedor lo tipea el usuario y no sale de nuestra secuencia— y `_check_l10n_latam_documents` se niega a postear sin él.

Que le toque o no un diario así **no depende del cambio que se esté testeando**: el test no arma sus propios datos, `setUp` toma la primera compañía, el primer partner y los primeros diarios que encuentra en la base:

```python
self.first_company = self.env["res.company"].search([], limit=1)
self.first_company_purchase_journal = self.env["account.journal"].search(
    [("company_id", "=", self.first_company.id), ("type", "=", "purchase")], limit=1
)
```

Así que el resultado depende de qué localizaciones instale el build. Por eso viene apareciendo en PRs que no tocan nada de este módulo.

## Solución

Completar el número antes de postear, solo cuando el diario realmente lo exige cargado a mano.

El valor no puede ser un literal único: los formatos son incompatibles entre localizaciones. `l10n_ar` parte el número por el guion y rechaza lo que no traiga las dos partes (`_format_document_number`, que además normaliza `1-1` a `00001-00000001`); `l10n_cl` exige solo dígitos (`_check_l10n_latam_document_number_is_numeric`). El helper ramifica por país.

Va con guarda sobre la existencia del campo, porque `l10n_latam_invoice_document` no es dependencia de este módulo.

## Test plan

Sobre una base 18.0 con `l10n_ar` y el módulo instalado:

- Sin el fix: `test_account_receivable` reproduce el error exacto de CI (`Please set the document number on the following invoices [79]`).
- Con el fix: `0 failed, 0 error(s) of 1 tests`.
- Suite completa del módulo con el fix: `0 failed, 0 error(s) of 3 tests`.

`pre-commit` verde.

## Lo que este PR NO arregla

La rama chilena del helper está razonada sobre el código de `l10n_cl`, no verificada corriendo el test: en una base donde la primera compañía es chilena, `test_account_receivable` falla **antes** de llegar al número de documento, con

```
Document types for foreign customers must be export type (codes 110, 111 or 112)...
```

porque `self.partner_ri = self.env["res.partner"].search([], limit=1)` puede levantar un partner extranjero. Es la misma clase de problema —el test depende de la data ambiente— pero en otro campo, y no es lo que rompe hoy en CI.

La solución de fondo sería que el test arme su propia compañía, su partner y sus diarios en vez de tomar los primeros de la base. Eso toca el `setUp` compartido por los tres tests de la clase y lo dejo fuera de este PR, que apunta a destrabar la cola de merges.
