### PR TITLE
[FIX] account_multicompany_ux: drop unasserted action_post in receivable test

### DIFF
--- a/account_multicompany_ux/tests/test_account_multicompany_ux_unit_test.py
+++ b/account_multicompany_ux/tests/test_account_multicompany_ux_unit_test.py
@@ -206,9 +206,6 @@ class TestAccountMulticompanyUxUnitTest(TransactionCase):
         self.assertTrue(self.account_receivable.id in customer_invoice.line_ids.mapped("account_id.id"))
         self.assertTrue(self.account_payable.id in vendor_bill.line_ids.mapped("account_id.id"))
 
-        customer_invoice.action_post()
-        vendor_bill.action_post()
-
     def test_change_company_keeps_ar_perception_move_line(self):
         """Regresión ticket 122289: al cambiar de compañía una factura con percepción AR,
         el apunte contable de la percepción debe seguir existiendo.


### PR DESCRIPTION
## Problema

`test_account_receivable` falla siempre en los builds de Saas 18.0 y pasa en los builds genéricos.

El test termina con `customer_invoice.action_post()` y `vendor_bill.action_post()` **después** de sus asserts, sin verificar nada sobre los asientos posteados.

En builds con localización LATAM (`l10n_latam_invoice_document`, que entra vía `l10n_ar`) los diarios de compra tienen `l10n_latam_manual_document_number = True`: el número de una factura de proveedor lo carga el usuario, no se genera solo. El test nunca lo setea, así que `_check_l10n_latam_documents` corta:

```
File ".../tests/test_account_multicompany_ux_unit_test.py", line 210, in test_account_receivable
    vendor_bill.action_post()
...
File ".../l10n_latam_invoice_document/models/account_move.py", line 199, in _check_l10n_latam_documents
odoo.exceptions.ValidationError: Please set the document number on the following invoices [70].
```

Los dos asserts y el post de la factura de cliente pasan; falla solo el post de la factura de proveedor.

## Solución

Se sacan los dos `action_post()`. Setear el número tampoco sirve acá: `account_multicompany_ux` es genérico y el formato del número cambia por localización (AR, CL y UY conviven en los builds de Saas), así que ese parche se rompería en el próximo build.

Las cuentas por cobrar/pagar que el test verifica ya están en `line_ids` con la factura en borrador, que es lo que el docstring declara probar. No se pierde cobertura de assert.

## Test plan

Corrido en dos bases locales, antes y después del cambio:

| Base | Antes | Después |
|---|---|---|
| `saas_client_l10n_ar` + `account_multicompany_ux`, con demo | `0 failed, 1 error(s) of 2 tests` | `0 failed, 0 error(s) of 3 tests` |
| `account_multicompany_ux` solo (genérico), con demo | `0 failed, 0 error(s) of 2 tests` | `0 failed, 0 error(s) of 3 tests` |

Incluye el `test_change_company_keeps_ar_perception_move_line` que entró recién en 18.0.