### PR TITLE
[FIX] account_multicompany_ux: use the downpayment account of the order company

### DIFF
--- a/account_multicompany_ux/models/__init__.py
+++ b/account_multicompany_ux/models/__init__.py
@@ -14,3 +14,4 @@ from . import product_category
 from . import account_account
 from . import account_report
 from . import account_move_line
+from . import sale_order_line

--- a/account_multicompany_ux/models/product_template.py
+++ b/account_multicompany_ux/models/product_template.py
@@ -26,6 +26,12 @@ class ProductTemplate(models.Model):
         compute="_compute_properties",
     )
 
+    def _get_downpayment_or_income_account(self, company, fiscal_pos=None):
+        """Account to be used on a downpayment line of the given company: the downpayment
+        account of the product category, or the income account when there is none."""
+        accounts = self.with_company(company).get_product_accounts(fiscal_pos=fiscal_pos)
+        return accounts.get("downpayment") or accounts.get("income")
+
     @api.depends()
     def _compute_properties(self):
         company_property = self.env["res.company.property"]

--- a/account_multicompany_ux/models/sale_order_line.py
+++ b/account_multicompany_ux/models/sale_order_line.py
@@ -1,0 +1,34 @@
+##############################################################################
+# For copyright and license notices, see __manifest__.py file in module root
+# directory
+##############################################################################
+from odoo import models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = "sale.order.line"
+
+    def _prepare_invoice_line(self, **optional_values):
+        """On downpayment lines odoo reuses the account of the already invoiced
+        downpayment without checking its company. If that invoice was moved to another
+        company (the change company wizard, or just picking a journal of another company
+        while it was a draft), the account is not valid here and the final invoice is
+        rejected with "Incompatible companies on records". Take the downpayment account
+        of the order company instead, and if there is none drop the account so that
+        account.move.line computes it."""
+        res = super()._prepare_invoice_line(**optional_values)
+        account = self.env["account.account"].browse(res.get("account_id"))
+        company = self.company_id
+        if not account or not company or account.filtered_domain(account._check_company_domain(company)):
+            return res
+        del res["account_id"]
+        # a downpayment line may have no product of its own, or one without accounts, so
+        # the search continues on the products of the order as the change company wizard does
+        templates = self.product_id.product_tmpl_id | self.order_id.order_line.product_id.product_tmpl_id
+        fiscal_pos = self.order_id.fiscal_position_id
+        for template in templates:
+            account = template._get_downpayment_or_income_account(company, fiscal_pos)
+            if account.filtered_domain(account._check_company_domain(company)):
+                res["account_id"] = account.id
+                break
+        return res

--- a/account_multicompany_ux/wizards/account_change_company.py
+++ b/account_multicompany_ux/wizards/account_change_company.py
@@ -303,10 +303,7 @@ class AccountChangeCurrency(models.TransientModel):
         products = line.sale_line_ids.mapped("order_id.order_line.product_id")
         product_accounts = []
         for product in products:
-            accounts = product.product_tmpl_id.with_company(line.move_id.company_id).get_product_accounts(
-                fiscal_pos=fiscal_pos
-            )
-            account = accounts.get("downpayment") or accounts.get("income")
+            account = product.product_tmpl_id._get_downpayment_or_income_account(line.move_id.company_id, fiscal_pos)
             if account:
                 product_accounts.append((product, account))
         if product_accounts:
@@ -314,10 +311,7 @@ class AccountChangeCurrency(models.TransientModel):
 
             if matching:
                 matched_product = matching[0][0]
-                matched_account = matched_product.product_tmpl_id.with_company(to_company).get_product_accounts(
-                    fiscal_pos=fiscal_pos
-                )
-                account = matched_account.get("downpayment") or matched_account.get("income")
+                account = matched_product.product_tmpl_id._get_downpayment_or_income_account(to_company, fiscal_pos)
 
         if not account:
             line.with_company(to_company.id)._compute_account_id()


### PR DESCRIPTION
## What

`sale._prepare_invoice_line` reuses the account of the already invoiced downpayment without checking its company. When the downpayment invoice lives in another company than its order, the deduction line of the final invoice gets an account of the other company and `_check_company` rejects it: *"Incompatible companies on records"*. The order is stuck — it fails with "Deduct down payments", and without deducting it invoices the full amount again.

A downpayment invoice reaches another company by two paths: `account.move.company_id` is computed from `journal_id`, so picking a journal of another company while the invoice is a draft moves it silently, and the `account.change.company` wizard of this module does it on purpose.

## How

Override `_prepare_invoice_line` on `sale.order.line`: if the inherited account is not valid for the company of the order line, resolve it on that company — downpayment account of the product category, income account otherwise.

That criterion already lived inside `_get_change_downpayment_account`, repeated twice. It is extracted into `product.template._get_downpayment_or_income_account`, and both the wizard and the new override call it, so there is one place where "which account does a downpayment line use on company X" is decided.

Only the criterion is shared, not the whole wizard method: its fallback does `line.with_company(to_company)._compute_account_id()`, which writes `account_id` on the line it receives — in this path a line of the already posted downpayment invoice.

A downpayment line does not always have a product of its own, and the one it has may have no accounts configured, so the search starts on the line product and continues on the products of the order, again like the wizard does.

When no product has either account, `account_id` is dropped from the values so that `account.move.line._compute_account_id` resolves it. The explicit lookup is still needed because that compute only considers the income account (`accounts['income']`), never the downpayment one, so dropping the account alone would silently change the account used for downpayments.

## Why here

`sale_order_type_ux` already carries this fix for its own users (17a8ccf1, `ingadhoc/sale#1396`). It belongs here instead: the problem has nothing to do with sale order types — any database with more than one company can hit it, and those without that module have no fix at all today. The override in `sale_order_type_ux` becomes redundant and is removed in ingadhoc/sale#1849, same branch name so runbot builds both together. While both exist they do not conflict: this one runs first through `super()` and leaves a valid account, so the other one finds nothing to fix.

The module already owns cross-company account resolution: the change company wizard remaps accounts, taxes and payment terms, and it is the module that makes `property_account_downpayment_categ_id` per company.

## Test plan

1. Companies A and B, own chart of accounts each, user with access to both.
2. Sale order in B, confirmed.
3. Invoice → Down payment. The draft is created in B.
4. Move the invoice to A (change company wizard, or change its journal to a sales journal of A). Post it.
5. Back on the order → Create invoice with "Deduct down payments".

Before: `UserError` *"Incompatible companies on records"*. After: the invoice is created and the deduction line takes the downpayment account of B (income account of the product if the category has none).

Worth checking as well:

- a plain order with a downpayment in the same company still takes the downpayment account of the original invoice, i.e. no change in the single-company flow;
- a downpayment line without product still gets an account of its own company;
- the change company wizard still resolves the same accounts as before on an invoice with downpayment lines (the extraction is meant to be behaviour-preserving).

Internal ticket: https://www.adhoc.inc/odoo/helpdesk.ticket/127169
